### PR TITLE
test: Refactor required env var tests to table format

### DIFF
--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -134,68 +134,6 @@ func TestMissingRequiredEnvironmentVariable(t *testing.T) {
 	}
 }
 
-func TestNoKeyForOpenAI(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), time.Duration(1*time.Second))
-	cmd := startProxyCmd(ctx, newDefaultTestConfig())
-
-	newEnv := []string{}
-	for _, envVar := range cmd.Env {
-		if match, _ := regexp.MatchString("^OPENAI_API_KEY=.*$", envVar); match {
-			continue
-		}
-
-		newEnv = append(newEnv, envVar)
-	}
-	cmd.Env = newEnv
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	require.Error(t, err, fmt.Sprintf("expected %s to fail", cmd.String()))
-
-	assert.Contains(t, stdout.String(), "level=ERROR msg=\"OPENAI_API_KEY is required\"")
-	assert.Contains(t, stderr.String(), "fatal: OPENAI_API_KEY is required")
-
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		assert.Equal(t, 1, exitErr.ExitCode(), "expected exit code to equal 1")
-	} else {
-		t.Fatalf("%v is not an exit error", err)
-	}
-}
-
-func TestNoBaseURLForOpenAI(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), time.Duration(1*time.Second))
-	cmd := startProxyCmd(ctx, newDefaultTestConfig())
-
-	newEnv := []string{}
-	for _, envVar := range cmd.Env {
-		if match, _ := regexp.MatchString("^OPENAI_BASE_URL=.*$", envVar); match {
-			continue
-		}
-
-		newEnv = append(newEnv, envVar)
-	}
-	cmd.Env = newEnv
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	require.Error(t, err, fmt.Sprintf("expected %s to fail", cmd.String()))
-
-	assert.Contains(t, stdout.String(), "level=ERROR msg=\"OPENAI_BASE_URL is required\"")
-	assert.Contains(t, stderr.String(), "fatal: OPENAI_BASE_URL is required")
-
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		assert.Equal(t, 1, exitErr.ExitCode(), "expected exit code to equal 1")
-	} else {
-		t.Fatalf("%v is not an exit error", err)
-	}
-}
-
 func launchApiServer(ctx context.Context, conf config) (string, func() error, error) {
 	cmd := startProxyCmd(ctx, conf)
 


### PR DESCRIPTION
## Summary
Refactors two existing tests for missing required environment variables into a table-driven test to cut down on repetition and increase readability.

## Demo

![Screenshot 2024-12-03 at 4 05 56 PM](https://github.com/user-attachments/assets/7e24bbee-7863-4aaa-98ed-625e9bd18e32)


