### PR TITLE
chore: remove repetitive vitest imports

### DIFF
--- a/src/components/Chat/Messages/Messages.test.tsx
+++ b/src/components/Chat/Messages/Messages.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach, Mock, afterAll } from "vitest";
+import { Mock } from "vitest";
 import { INTRO_MESSAGE, Messages } from "./Messages";
 import { useSelector } from "react-redux";
 import { selectMessageHistory } from "../../../stores";

--- a/src/components/Chat/PromptInput/PromptInput.test.tsx
+++ b/src/components/Chat/PromptInput/PromptInput.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach, afterAll, Mock } from "vitest";
+import { Mock } from "vitest";
 import { PromptInput } from "./PromptInput";
 import { useSelector } from "react-redux";
 import { selectHasToolCallInProgress } from "../../../stores";

--- a/src/components/Chat/StreamingMessage/StreamingMessage.test.tsx
+++ b/src/components/Chat/StreamingMessage/StreamingMessage.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach, Mock, afterAll } from "vitest";
+import { Mock } from "vitest";
 import { StreamingMessage } from "./StreamingMessage";
 import { useSelector } from "react-redux";
 import { selectStreamingMessage } from "../../../stores";

--- a/src/components/DemoBanner/index.test.tsx
+++ b/src/components/DemoBanner/index.test.tsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react'
-import { describe, it } from 'vitest';
 import { DemoBanner } from './';
 
 describe('DemoBanner', () => {

--- a/src/contexts/AppContext.test.tsx
+++ b/src/contexts/AppContext.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { Mock } from 'vitest';
 import { AppContextProvider } from './AppContext';
 import { useAppContext } from './AppContext';
 import * as stores from '../stores';
@@ -132,7 +132,7 @@ describe('AppContextProvider', () => {
             </AppContextProvider>
         );
 
-        
+
         fireEvent.click(screen.getByText('Submit Chat Message'));
 
 

--- a/src/stores/msgStore/index.test.ts
+++ b/src/stores/msgStore/index.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from 'vitest';
 import {
     msgStoreReducer,
     streamingMessageConcat,
@@ -14,8 +13,6 @@ import {
 } from './index';
 import type { ChatCompletionMessageParam } from 'openai/resources/index';
 
-
-
 const initialState: MsgStore = {
     history: [
         {
@@ -26,9 +23,7 @@ const initialState: MsgStore = {
     streamingMessage: '',
 };
 
-
 describe('reducers', () => {
-
     describe('streamingMessageConcat', () => {
         it('should append payload to streamingMessage', () => {
             const action = streamingMessageConcat('Hello, ');
@@ -166,8 +161,6 @@ describe('reducers', () => {
             expect(newState.history[2]).toEqual( { role: 'assistant', content: 'how can i help you?' });
 
         })
-
-
     });
 });
 
@@ -215,8 +208,7 @@ describe('selectors', () => {
         });
 
         expect(selected).toBe(true);
-    })
-
+    });
 
     it('selectHasToolCallInProgress should return false when there is a tool call is finished', () => {
         const selected = selectHasToolCallInProgress({
@@ -232,7 +224,6 @@ describe('selectors', () => {
         });
 
         expect(selected).toBe(false);
-    })
-
+    });
 
 });

--- a/src/utils/chat/chat.test.ts
+++ b/src/utils/chat/chat.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, Mock } from 'vitest';
+import { Mock } from 'vitest';
 import { chat } from './chat';
 import OpenAI from 'openai';
 import type { ChatCompletionChunk } from 'openai/resources/index';
@@ -253,7 +253,7 @@ describe('chat function', () => {
   });
 
 
-  // sometimes openAI sends empty content chunks 
+  // sometimes openAI sends empty content chunks
   // this tests that we can handle that and not call onDone
   it('should handle empty content chunks gracefully', async () => {
     // Mock OpenAI client

--- a/src/utils/token/token.test.ts
+++ b/src/utils/token/token.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, Mock } from 'vitest';
+import { Mock } from 'vitest';
 import { getIDFromStorage, getToken, IDKEY } from './token';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,6 +1,5 @@
 import OpenAI from 'openai';
 import { v4 as uuidv4 } from 'uuid';
-import { describe, expect, it } from 'vitest';
 
 const PROXY_ENDPOINT= process.env.PROXY_ENDPOINT
 const BYPASS_PROXY = process.env.BYPASS_PROXY === 'true';

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,7 +8,6 @@
     "skipLibCheck": true,
 
     "types": ["@testing-library/jest-dom/vitest"],
-    /* Bundler mode */
     "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
@@ -16,12 +15,15 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
-    /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": [
+    "src",
+    "node_modules/vitest/globals.d.ts",
+    "tests/**/*.ts"
+  ]
 }

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -10,6 +10,7 @@ export default defineWorkspace([
       environment: "jsdom",
       setupFiles: './vitestSetup.ts',
       exclude: [...configDefaults.exclude, "e2e"],
+      globals: true,
     }
   },
   {
@@ -18,6 +19,7 @@ export default defineWorkspace([
       root: './tests',
       include: ['**/*.test.ts'],
       environment: 'node',
+      globals: true,
     }
   }
 ])


### PR DESCRIPTION
## Summary
- adjusts tsconfig.app.json to compile vitest globals like "describe", "expect", "it", etc.
- adjusts both workspaces to allow for `globals` to be used without imports
- note that `Mock` is not a global and will still need to be imported from vitest when used

