### PR TITLE
feat: add `KAVACHAT_API_HOST` support for proxy 

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -23,7 +23,6 @@ const (
 
 var ErrOpenAIKeyRequired = errors.New("OPENAI_API_KEY is required")
 var ErrOpenAIBaseURLRequired = errors.New("OPENAI_BASE_URL is required")
-var ErrAPIHostRequired = errors.New("KAVACHAT_API_HOST is required")
 
 func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -41,7 +41,7 @@ func newDefaultTestConfig() config {
 		// don't use external URL's by default
 		baseURL: "http://localhost:5556/v1",
 		port:    0,
-		host:    "0.0.0.0",
+		host:    "127.0.0.1",
 	}
 }
 


### PR DESCRIPTION
## Summary
- Addresses https://github.com/Kava-Labs/kavachat/issues/27
- Requires either 127.0.0.1 or 0.0.0.0 as `KAVACHAT_API_HOST`
- Throws errors if this value isn't set or differs
- Errors verified by additional cases in existing table test, which needing minor revisions now that multiple env var's need transformation into junk values

