### PR TITLE
fix: listen on all addresses in docker proxy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
       # Pass through existing environment variables
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL}
+      KAVACHAT_HOST: "0.0.0.0"
 
   kavanode:
     image: "kava/kava:${KAVA_TAG:-v0.27.0-goleveldb}"


### PR DESCRIPTION
## Summary

Configured the proxy spun up with docker to listen to all addresses (instead of 127.0.0.1). This allows it to be connected to from outside the container, like via the locally running webapp.
