### PR TITLE
fix: adjust connect wallet button to have fixed width

### DIFF
--- a/src/components/ChatControls/ChatControls.tsx
+++ b/src/components/ChatControls/ChatControls.tsx
@@ -1,4 +1,4 @@
-import styles from '../../style.module.css';
+import styles from './styles.module.css';
 import { ConnectWallet } from './ConnectWallet';
 import { ResetButton } from './ResetButton';
 

--- a/src/components/ChatControls/ConnectWallet/ConnectWallet.tsx
+++ b/src/components/ChatControls/ConnectWallet/ConnectWallet.tsx
@@ -1,11 +1,11 @@
 import { useAppContext } from '../../../contexts/AppContext';
-import styles from '../../../style.module.css';
+import styles from '../styles.module.css';
 
 export const ConnectWallet = () => {
   const { connectWallet, address } = useAppContext();
   return (
     <button
-      className={styles.active}
+      className={styles.connectWalletButton}
       onClick={(e) => {
         e.preventDefault();
         connectWallet();

--- a/src/components/ChatControls/ResetButton/ResetButton.tsx
+++ b/src/components/ChatControls/ResetButton/ResetButton.tsx
@@ -1,4 +1,4 @@
-import styles from '../../../style.module.css';
+import styles from '../styles.module.css';
 
 export const ResetButton = ({
   clearMessages,

--- a/src/components/ChatControls/styles.module.css
+++ b/src/components/ChatControls/styles.module.css
@@ -1,5 +1,11 @@
-.header {
-  padding: 16px 16px 16px 24px;
+.active {
+  background-color: rgb(160, 181, 255);
+  color: rgb(45, 45, 45);
+}
+
+.active:hover {
+  background-color: rgb(78, 87, 246);
+  color: rgb(238, 238, 238);
 }
 
 .chatControls {
@@ -23,19 +29,14 @@
   cursor: pointer;
 }
 
-.active {
-  background-color: rgb(160, 181, 255);
-  color: rgb(45, 45, 45);
-}
-
 .chatControls .inactive {
   background-color: rgb(75, 75, 75);
   color: rgb(45, 45, 45);
   cursor: unset;
 }
 
-.active:hover {
-  background-color: rgb(78, 87, 246);
-  color: rgb(238, 238, 238);
+.connectWalletButton {
+  background-color: rgb(160, 181, 255);
+  color: rgb(45, 45, 45);
+  width: 175px
 }
-

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,5 +1,5 @@
 import kavaLogo from '../../assets/kavaLogo.svg';
-import styles from '../../style.module.css';
+import styles from './styles.module.css';
 
 export const Header = () => {
   return (

--- a/src/components/Header/styles.module.css
+++ b/src/components/Header/styles.module.css
@@ -1,0 +1,3 @@
+.header {
+  padding: 16px 16px 16px 24px;
+}


### PR DESCRIPTION
## Summary
- give that button a width just large enough that the button doesn't become wider when its text changes to "Reconnect wallet"
- emptied out styles.module.css in src/ and moved classes to style sheets within the corresponding module
- note since some styles are shared between ConnectWallet and ResetButton, those styles are in the style sheet for its parent ChatControls (along with the chat controls classes too)
- "looks good on mobile"

## Demo 
#### Before
Notice the button get wider with the longer text

https://github.com/user-attachments/assets/bc3195fd-7d0b-4ef9-a8db-0d8daadce703



#### After

https://github.com/user-attachments/assets/98f5a932-258c-433a-a349-b0c9df47d82d


