### PR TITLE
fix: Download artifact from workflow_run event id

### DIFF
--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -55,6 +55,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: kavachat-api-docker-image-name
+          # Run ID of the CI job that triggered workflow_run event
+          run-id: ${{ github.event.workflow_run.id }}
           path: image-name.txt
 
       - name: Read full Docker image name from artifacts


### PR DESCRIPTION
## Summary

fixes error

```
Unable to download artifact(s): Artifact not found for name: kavachat-api-docker-image-name
```