### PR TITLE
refactor(ci): Reusable deployment workflow

### DIFF
--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -110,7 +110,7 @@ jobs:
           push: true
           tags: ${{ steps.image-name.outputs.image }}
 
-  deploy-api:
+  deploy-production-api:
     needs: docker-build-test
     # Limit to only run on main branch pushes
     if: ${{ (github.ref == 'refs/heads/main') && github.event_name == 'push' }}
@@ -122,5 +122,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     with:
-      environment: api-production
+      environment-name: api-production
+      environment-url: https://kavachat-api.production.kava.io
       image-name: ${{ needs.docker-build-test.outputs.image-name }}

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -2,7 +2,7 @@ name: Deploy API
 
 # Ensure only 1 deployment is running at a time for each environment
 concurrency:
-  group: ${{ inputs.environment }}
+  group: ${{ inputs.environment-name }}
   # Do NOT cancel in-progress deployments, ensure each deployment completes
   # before starting the next one. This allows for rollbacks to the latest most
   # stable version, instead of potentially skipping over a stable version.
@@ -16,9 +16,13 @@ on:
         required: true
         description: 'Full Docker image name to deploy'
         type: string
-      environment:
+      environment-name:
         required: true
-        description: 'Environment to deploy to'
+        description: 'Name of environment to deploy to'
+        type: string
+      environment-url:
+        required: true
+        description: 'URL of the environment'
         type: string
     # These are set in **environment** settings, not repository-wide secrets.
     # The values in the parent workflow are replaced with the values environment
@@ -43,18 +47,18 @@ env:
 
 jobs:
   deploy:
-    name: Deploy ${{ inputs.environment }}
+    name: Deploy ${{ inputs.environment-name }}
     runs-on: ubuntu-latest
-    # Ensure the inputs are set
-    if: ${{ inputs.image-name != '' && inputs.environment != '' }}
-    environment: ${{ inputs.environment }}
+    environment:
+      name: ${{ inputs.environment-name }}
+      url: ${{ inputs.environment-url }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Output image name
-        run: echo "Deploying Docker image '${{ inputs.image-name }}' to '${{ inputs.environment }}'"
+        run: echo "Deploying Docker image '${{ inputs.image-name }}' to '${{ inputs.environment-name }}'"
 
       - name: Configure AWS credentials for service deployment
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
## Summary
- workflow_call child workflows is not great
- Converts to reusable workflow that can also be used for other environments
- Much easier to pass values to child workflow
- Moved production AWS secrets to api-production **environment** secrets instead of repo secrets
