### PR TITLE
test: unskip AppContext test

### DIFF
--- a/src/contexts/AppContext.test.tsx
+++ b/src/contexts/AppContext.test.tsx
@@ -33,7 +33,7 @@ vi.mock('../utils', () => ({
 }));
 
 //  todo - unskip when this test is plugged into a redux provider
-describe.skip('AppContextProvider', () => {
+describe('AppContextProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Mock window.ethereum

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -80,8 +80,8 @@ export function AppContextProvider({
   const [address, setAddress] = useState('');
   const [cancelStream, setCancelStream] = useState<null | (() => void)>(null);
 
-  useSyncToStorage(storage);
-  useSyncFromStorageOnReload(storage, store);
+  useSyncToStorage(store, storage);
+  useSyncFromStorageOnReload(store, storage);
 
   const markDownCache = useRef<Map<string, string>>(mdCache);
 
@@ -270,7 +270,7 @@ export function AppContextProvider({
     //  if we maintain parity between local storage and redux, we
     //  can inadvertently overwrite existing data in storage
     //  with an empty redux store before its repopulated
-    await storage.reset();
+    storage.reset();
     store.dispatch(messageHistoryClear());
     markDownCache.current.clear();
     try {

--- a/src/utils/storage/hooks.ts
+++ b/src/utils/storage/hooks.ts
@@ -3,7 +3,6 @@ import {
   messageHistorySet,
   selectMessageHistory,
 } from '../../stores';
-import { useSelector } from 'react-redux';
 import { useEffect } from 'react';
 import { LocalStorage } from './index';
 import { ChatHistory } from './types';
@@ -13,8 +12,11 @@ import { toast } from 'react-toastify';
  * when messages are added to msgHistory in redux (beyond just the initial system message), sync those messages
  * to local storage
  */
-export const useSyncToStorage = (storage: LocalStorage<ChatHistory>) => {
-  const msgHistory = useSelector(selectMessageHistory);
+export const useSyncToStorage = (
+  store: typeof _appStore,
+  storage: LocalStorage<ChatHistory>,
+) => {
+  const msgHistory = selectMessageHistory(store.getState());
 
   useEffect(() => {
     //  only write to storage if there's something more than system prompt in redux msgHistory
@@ -40,8 +42,8 @@ export const useSyncToStorage = (storage: LocalStorage<ChatHistory>) => {
  * if so, set that history in redux, resulting in a persisted UI state (conversation is saved)
  */
 export const useSyncFromStorageOnReload = (
-  storage: LocalStorage<ChatHistory>,
   store: typeof _appStore,
+  storage: LocalStorage<ChatHistory>,
 ) => {
   useEffect(() => {
     const syncFromLocalStorage = async () => {


### PR DESCRIPTION
## Summary
- Leverage the getters already mocked in test file (like 'selectMessageHistory' 'messageHistoryAddMessage') to access state like `selectMessageHistory(store.getState())`` instead of the more direct pattern of `useSelector(selectMessageHistory)`
- pass store into hook so we can call `getState`
- reorder arguments between the two hooks for consistency
