### PR TITLE
test: verify clicking "reset chat" clears local storage chat history

### DIFF
--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -264,5 +264,5 @@ test('clicking "reset chat" clears "chatMessages" from local storage', async ({
     localStorage.getItem('chat-messages'),
   );
 
-  expect(JSON.parse(updatedLocalStorage)).toBeNull();
+  expect(updatedLocalStorage).toBeNull();
 });


### PR DESCRIPTION
## Summary
- adds playwright test to verify clearing local storage

