### PR TITLE
feat: iFrame PostMessge with token metadata

### DIFF
--- a/public/parent.html
+++ b/public/parent.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Parent Page</title>
+    <style>
+      body {
+        height: 90vh;
+      }
+      iframe {
+        width: 100%;
+        height: 100%;
+        border: none;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Embed the React app served by the dev server -->
+    <div id="iframe-root" style="width: 400px; height: 600px"></div>
+
+    <div>
+      <button id="open_chat">Open Chat</button>
+    </div>
+
+    <div id="GENERATED_TOKEN_METADATA"></div>
+
+    <script>
+      document.getElementById('open_chat').addEventListener('click', () => {
+        console.log(document.getElementById('iframe-root'));
+        if (document.getElementById('iframe-root').innerHTML) {
+          document.getElementById('iframe-root').innerHTML = '';
+          document.getElementById('open_chat').innerText = 'Open Chat';
+          document.getElementById('GENERATED_TOKEN_METADATA').innerHTML = '';
+          return;
+        }
+
+        document.getElementById('iframe-root').innerHTML =
+          `<iframe id="KAVA_CHAT" src="http://localhost:3000"></iframe>`;
+
+        document.getElementById('open_chat').innerText = 'Close Chat';
+      });
+
+      window.addEventListener('message', (event) => {
+        if (event.data.type && event.data.type === 'GENERATED_TOKEN_METADATA') {
+          // render the received data from the iFrame
+          document.getElementById('GENERATED_TOKEN_METADATA').innerHTML = `
+        <h1>Received iFrame message from chat App</h1>
+        <h3>Name: ${event.data.payload.tokenName}</h3>
+        <h3>Symbol: ${event.data.payload.tokenSymbol}</h3>
+        <h3>Description</h3>
+        <p>${event.data.payload.tokenDescription}</p>
+        <h3>Token Image</h3>
+        <img
+          alt="Model Generated Image"
+          src="data:image/png;base64,${event.data.payload.base64ImageData}"
+        />
+          `;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/components/Chat/GeneratedToken/GeneratedToken.tsx
+++ b/src/components/Chat/GeneratedToken/GeneratedToken.tsx
@@ -47,6 +47,30 @@ export const GeneratedToken = (props: GenerateTokenMetadataResponse) => {
           alt="Model Generated Image"
           src={`data:image/png;base64,${imgData}`}
         />
+
+        <button
+          className={styles.submitButton}
+          onClick={() => {
+            const isInsideIFrame = window.self !== window.top;
+            if (isInsideIFrame) {
+              console.log('sending message to parent');
+              window.parent.postMessage(
+                {
+                  type: 'GENERATED_TOKEN_METADATA',
+                  payload: {
+                    base64ImageData: imgData,
+                    tokenName: props.name,
+                    tokenSymbol: props.symbol,
+                    tokenDescription: props.about,
+                  },
+                },
+                '*', // target origin is * for now (wherever we are embedded) later we want to restrict this to only work with hard.fun
+              );
+            }
+          }}
+        >
+          launch
+        </button>
       </div>
     </div>
   );

--- a/src/tools/toolFunctions.ts
+++ b/src/tools/toolFunctions.ts
@@ -244,23 +244,6 @@ export const generateCoinMetadata = async ({
 
   const id = await saveImage(b64ImageData);
 
-  const isInsideIFrame = window.self !== window.top;
-  if (isInsideIFrame) {
-    console.log('sending message to parent');
-    window.parent.postMessage(
-      {
-        type: 'GENERATED_TOKEN_METADATA',
-        payload: {
-          base64ImageData: b64ImageData,
-          tokenName: name,
-          tokenSymbol: symbol,
-          tokenDescription: about,
-        },
-      },
-      '*', // target origin is * for now (wherever we are embedded) later we want to restrict this to only work with hard.fun
-    );
-  }
-
   return {
     name,
     id,


### PR DESCRIPTION
## Demo 
an html page with a tiny bit of js that when the message gets received from the chat app, removes the iFrame from the DOM and renders the token meta data. 

here's the html for the parent app: 

```
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Parent Page</title>
    <style>
      body {
        height: 90vh;
      }
      iframe {
        width: 100%;
        height: 100%;
        border: none;
      }
    </style>
  </head>
  <body>
    <div id="GENERATED_TOKEN_METADATA"></div>
    <!-- Embed the React app served by the dev server -->
    <iframe id="KAVA_CHAT" src="http://localhost:3000"></iframe>

    <script>
      window.addEventListener("message", (event) => {
        if (event.data.type && event.data.type === "GENERATED_TOKEN_METADATA") {
          const iframe = document.getElementById("KAVA_CHAT");
          // remove the chat app iFrame
          if (iframe) {
            iframe.parentNode.removeChild(iframe);
          }
          // render the received data from the iFrame
          document.getElementById("GENERATED_TOKEN_METADATA").innerHTML = `
        <h1>Received iFrame message from chat App</h1>
        <h3>Name: ${event.data.payload.tokenName}</h3>
        <h3>Symbol: ${event.data.payload.tokenSymbol}</h3>
        <h3>Description</h3>
        <p>${event.data.payload.tokenDescription}</p>
        <h3>Token Image</h3>
        <img
          alt="Model Generated Image"
          src="data:image/png;base64,${event.data.payload.base64ImageData}"
        />
          `;
        }
      });
    </script>
  </body>
</html>

```



https://github.com/user-attachments/assets/f44fe935-e8ef-45b8-8706-86c57257aeee



