### PR TITLE
fix: Add openai base url for prod for frontent CD build

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,6 +20,8 @@ jobs:
   build-frontend:
     name: Build frontend
     runs-on: ubuntu-latest
+    env:
+      VITE_OPENAI_BASE_URL: https://kavachat-api.production.kava.io/openai/v1
     outputs:
       changed: ${{ steps.diff.outputs.diff != '' }}
     steps:


### PR DESCRIPTION
Since the netlify deployment is built locally in CI now, we need to add this env variable before vite processes them.