### PR TITLE
style: match button group width to other elements

### DIFF
--- a/src/components/Chat/style.module.css
+++ b/src/components/Chat/style.module.css
@@ -49,7 +49,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  max-width: 1010px;
+  max-width: 1000px;
 }
 
 /* Input field styles */

--- a/src/components/ChatControls/styles.module.css
+++ b/src/components/ChatControls/styles.module.css
@@ -15,7 +15,7 @@
   border-radius: 10px;
 
   width: 100%;
-  max-width: 1010px;
+  max-width: 1000px;
   margin: 10px auto 0;
   /* Added top margin for spacing */
 }


### PR DESCRIPTION
## Summary
move max-width onto input parent and match button group width to match other elements

## Before

![Screenshot 2024-12-16 at 10 50 59 AM](https://github.com/user-attachments/assets/4a0fedfd-1be1-41d0-a224-b1c2d006d838)

## After
![Screenshot 2024-12-16 at 10 53 55 AM](https://github.com/user-attachments/assets/ddcc0294-b246-492a-807f-4af12d5a28d7)
