### PR TITLE
feat: make token card placeholder scroll on render

### DIFF
--- a/src/Content.tsx
+++ b/src/Content.tsx
@@ -4,7 +4,7 @@ import styles from './ChatView.module.css';
 
 export interface ContentProps {
   content: string;
-  onRendered(): void;
+  onRendered?: () => void;
   role: string;
 }
 
@@ -49,7 +49,9 @@ export const ContentComponent = ({
   }, [content, sanitizedContent, setSanitizedContent]);
 
   useEffect(() => {
-    requestAnimationFrame(onRendered);
+    if (onRendered) {
+      requestAnimationFrame(onRendered);
+    }
   }, [sanitizedContent, hasError, onRendered]);
 
   if (hasError) {

--- a/src/Conversation.tsx
+++ b/src/Conversation.tsx
@@ -31,7 +31,6 @@ export const Conversation = ({
               <Content
                 role={message.role}
                 content={message.content as string}
-                onRendered={onRendered}
               />
             </div>
           );
@@ -48,7 +47,6 @@ export const Conversation = ({
                 <Content
                   role={message.role}
                   content={message.content as string}
-                  onRendered={onRendered}
                 />
               </div>
             </div>
@@ -146,6 +144,7 @@ export const Conversation = ({
 
       <TokenCardsStreamingPlaceholder
         toolCallStreamStore={toolCallStreamStore}
+        onRendered={onRendered}
       />
     </div>
   );

--- a/src/TokenCard.tsx
+++ b/src/TokenCard.tsx
@@ -107,13 +107,25 @@ export const TokenCard = ({
 
 export const TokenCardsStreamingPlaceholder = ({
   toolCallStreamStore,
+  onRendered,
 }: {
   toolCallStreamStore: ToolCallStreamStore;
+  onRendered: () => void;
 }) => {
   const toolCallStreams = useSyncExternalStore(
     toolCallStreamStore.subscribe,
     toolCallStreamStore.getSnapShot,
   );
+
+  useEffect(() => {
+    if (
+      toolCallStreams.find(
+        (tc) => tc.function.name === ToolFunctions.GENERATE_COIN_METADATA,
+      ) !== undefined
+    ) {
+      requestAnimationFrame(onRendered);
+    }
+  }, [toolCallStreams, onRendered]);
 
   return toolCallStreams.map((tcStream) => {
     if (tcStream.function.name !== ToolFunctions.GENERATE_COIN_METADATA) {


### PR DESCRIPTION
make onRendered component optional for Content component

because only the streaming message child Content should scroll the screen as it writes from the text store

## Summary

## Demo 

## Open Questions

## Follow-on tasks
