### PR TITLE
fix: Add z-index to prevent overflow in iframe

### DIFF
--- a/src/ChatView.module.css
+++ b/src/ChatView.module.css
@@ -244,6 +244,7 @@
   justify-content: flex-end;
   align-items: center;
   margin: 0px;
+  z-index: 99;
 
   @media (max-width: 640px) {
     padding: var(--space-sm) var(--space-sm);


### PR DESCRIPTION
This fixes a bug when the app is hosted in an iframe, some elements will scroll above the sticky header.  We set a z-index to prevent overflow over the header in the iframe scenario.