### PR TITLE
feat: open links in new tab 

### DIFF
--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -1,8 +1,41 @@
-import DOMPurify from 'dompurify';
 import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+interface SanitizeOptions {
+  ADD_ATTR: string[];
+  ALLOW_SCRIPTS: boolean;
+  ALLOW_UNKNOWN_PROTOCOLS: boolean;
+}
 
 export async function sanitizeContent(content: string): Promise<string> {
-  const htmlContent = await marked.parse(content);
-  const sanitizedHtml = DOMPurify.sanitize(htmlContent);
+  const htmlContent: string = await marked.parse(content);
+
+  // Configure links to open in new tabs
+  const afterSanitizeAttributes = (node: Element): void => {
+    if (node.tagName === 'A') {
+      const href = node.getAttribute('href');
+
+      if (!href || href.startsWith('javascript:')) {
+        node.removeAttribute('href');
+        return;
+      }
+
+      // Set attributes for opening in new tab securely
+      node.setAttribute('target', '_blank');
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+  };
+
+  DOMPurify.addHook('afterSanitizeAttributes', afterSanitizeAttributes);
+
+  const options: SanitizeOptions = {
+    ADD_ATTR: ['target', 'rel'],
+    ALLOW_SCRIPTS: false,
+    ALLOW_UNKNOWN_PROTOCOLS: false,
+  };
+
+  const sanitizedHtml = DOMPurify.sanitize(htmlContent, options);
+  DOMPurify.removeHook('afterSanitizeAttributes');
+
   return sanitizedHtml;
 }


### PR DESCRIPTION
## Summary
If content in the chat contains a link, by default, open that link in a new tab (and not in the chat window)


## Before 

https://github.com/user-attachments/assets/5a449986-8b82-4860-8002-51490a92d301


## After


https://github.com/user-attachments/assets/488c1e10-dfcd-49c8-a774-e67b1438cfca

