### PR TITLE
fix: disable sending new messages while tool call in confirmation

### DIFF
--- a/src/ChatView.tsx
+++ b/src/ChatView.tsx
@@ -62,7 +62,15 @@ export const ChatView = ({
   );
 
   const handleButtonClick = useCallback(() => {
-    if (isRequesting) {
+    const lastMessage = messages[messages.length - 1];
+    const lastMessageRole = lastMessage.role;
+
+    //  if a user has initiated a wallet-based tool call, but not confirmed or denied it
+    //  we don't want to add more messages to the history
+    const userRequestInProgress =
+      messages.length > 1 && lastMessageRole === 'user';
+
+    if (isRequesting || userRequestInProgress) {
       onCancel();
       return;
     }
@@ -82,7 +90,7 @@ export const ChatView = ({
 
     onSubmit(output);
     setInputValue('');
-  }, [isRequesting, onSubmit, onCancel, inputValue]);
+  }, [messages, isRequesting, inputValue, onSubmit, onCancel]);
 
   const buttonRef = useRef<HTMLButtonElement>(null);
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {


### PR DESCRIPTION
## Summary
Handles the follow edge case

- user sets up a transaction
- metamask window opens, but user doesn't confirm or deny
- user types a new message
- message history gets in a bad state (notice the two user messages in a row)

![Screenshot 2025-01-13 at 3 31 48 PM](https://github.com/user-attachments/assets/613c11d9-0094-43a3-a3ba-512535a8b76d)


## Before

https://github.com/user-attachments/assets/63e0ee45-b90d-42ea-acd7-faeea618341b


## After
A user can type in the chat, but can't submit that new message.

https://github.com/user-attachments/assets/0a2babdd-5688-4f4b-b27b-ebd01cc1d5ec


## Follow on

Perhaps this workflow could be improved

- User confirms tx by typing "yes"
- Assistant responds "Ok - confirm the transaction in your wallet to proceed"