### PR TITLE
fix: early return instead of throwing error when trying to add to streaming store when tool call in progress

### DIFF
--- a/src/toolCallStreamStore.ts
+++ b/src/toolCallStreamStore.ts
@@ -61,9 +61,12 @@ export class ToolCallStreamStore {
     if (streamingTc) {
       // If we already have a tool call for this "index", we just append new argument data.
       const streamParser = this.parsers.get(tc.index);
+      if (!streamParser) {
+        return;
+      }
       // The parser will handle streaming JSON. If the new data isn't valid JSON, it might throw.
       // caller should handle catching the error
-      streamParser!.write(tc.function?.arguments ?? '');
+      streamParser.write(tc.function?.arguments ?? '');
     } else {
       // If this is the first time we see this tool call, we need to set it up.
       this.addToolCall(tc);


### PR DESCRIPTION
## Description

Eliminates `Cannot read properties of undefined (reading 'write')` error that occurs when
- a tool call has been initiated, but not completed (i.e. sent to metamask)
- user types a new chat

## Before

https://github.com/user-attachments/assets/cedc71a1-d824-413a-9ab8-e72f81189f08


## After


https://github.com/user-attachments/assets/0e4db73d-b3ef-41a1-adcb-b8cd23286423

