### PR TITLE
test: wait up to 20 seconds for image generation e2e

### DIFF
--- a/e2e/Chat.ts
+++ b/e2e/Chat.ts
@@ -61,14 +61,19 @@ export class Chat {
   }
 
   async waitForImageGenerationToFinish() {
-    await this.page.waitForResponse(async (res) => {
-      if (res.url().includes('generations')) {
-        expect(res.status()).toBe(200);
-        await res.finished();
-        return true;
-      }
-      return false;
-    });
+    await this.page.waitForResponse(
+      async (res) => {
+        if (res.url().includes('generations')) {
+          expect(res.status()).toBe(200);
+          await res.finished();
+          return true;
+        }
+        return false;
+      },
+      {
+        timeout: 20000,
+      },
+    );
   }
 
   async waitForAssistantResponse() {


### PR DESCRIPTION
## Summary

PR #133 passed playwright e2e tests on the feature branch: https://github.com/Kava-Labs/oros/actions/runs/12776717758 but failed on merge to main: https://github.com/Kava-Labs/oros/actions/runs/12776947921/job/35616689797 when it timed out waiting for image generation endpoint to return success.


