### PR TITLE
ci: increase timeout to 40 seconds for image generation to address flakiness in build

### DIFF
--- a/e2e/Chat.ts
+++ b/e2e/Chat.ts
@@ -71,7 +71,7 @@ export class Chat {
         return false;
       },
       {
-        timeout: 20000,
+        timeout: 40000,
       },
     );
   }


### PR DESCRIPTION
## Summary
In recent merges to main, playwright failing as part of docker-build-test job: https://github.com/Kava-Labs/oros/actions/runs/12794484877/job/35669714198
but succeeds as its own task: https://github.com/Kava-Labs/oros/actions/runs/12794484850/job/35669713522

Trying increasing timeout from 20 seconds to 40 seconds to see if that fixes it.


