### PR TITLE
style: revert align right for long user messages

### DIFF
--- a/src/ChatView.module.css
+++ b/src/ChatView.module.css
@@ -59,7 +59,6 @@
 }
 
 .right {
-  text-align: right;
   flex-shrink: 0;
   border-radius: var(--borderRadius-md);
   background: var(--colors-bgTertiary);


### PR DESCRIPTION
## Summary
After reviewing other products in the AI landscape, others still align left for user message that overflow past a single line.
