### PR TITLE
refactor: consolidate content and role into singular message prop

### DIFF
--- a/src/Content.tsx
+++ b/src/Content.tsx
@@ -3,18 +3,15 @@ import { sanitizeContent } from './sanitize';
 import styles from './ChatView.module.css';
 import { unmaskAddresses } from './utils/chat/unmaskAddresses';
 import { enforceLineBreak, getStoredMasks } from './utils/chat/helpers';
+import { ChatCompletionMessageParam } from 'openai/resources/index';
 
 export interface ContentProps {
-  content: string;
+  message: ChatCompletionMessageParam;
   onRendered?: () => void;
-  role: string;
 }
 
-export const ContentComponent = ({
-  content,
-  onRendered,
-  role,
-}: ContentProps) => {
+export const ContentComponent = ({ message, onRendered }: ContentProps) => {
+  const { content, role } = message;
   const [hasError, setHasError] = useState(false);
   const [sanitizedContent, setSanitizedContent] = useState<string>('');
   const storedMasks = getStoredMasks();
@@ -30,7 +27,9 @@ export const ContentComponent = ({
 
       try {
         const updatedContent = await sanitizeContent(
-          enforceLineBreak(unmaskAddresses(content, storedMasks.masksToValues)),
+          enforceLineBreak(
+            unmaskAddresses(content as string, storedMasks.masksToValues),
+          ),
         );
         if (!cancel) {
           setSanitizedContent(updatedContent);

--- a/src/Conversation.tsx
+++ b/src/Conversation.tsx
@@ -18,7 +18,12 @@ export interface ConversationProps {
 }
 
 const StreamingTextContent = (message: string, onRendered: () => void) => {
-  return <Content role="assistant" content={message} onRendered={onRendered} />;
+  return (
+    <Content
+      message={{ role: 'assistant', content: message }}
+      onRendered={onRendered}
+    />
+  );
 };
 
 const ConversationComponent = ({
@@ -35,10 +40,7 @@ const ConversationComponent = ({
         if (message.role === 'user') {
           return (
             <div key={index} className={styles.right}>
-              <Content
-                role={message.role}
-                content={message.content as string}
-              />
+              <Content message={message} />
             </div>
           );
         }
@@ -48,10 +50,7 @@ const ConversationComponent = ({
             <div key={index} className={styles.left}>
               <img src={logo} className={styles.conversationChatIcon} />
               <div className={styles.assistantContainer}>
-                <Content
-                  role={message.role}
-                  content={message.content as string}
-                />
+                <Content message={message} />
               </div>
             </div>
           );
@@ -123,9 +122,8 @@ const ConversationComponent = ({
           <img src={logo} className={styles.conversationChatIcon} />
           <div className={styles.assistantContainer}>
             <Content
-              content={errorText}
+              message={{ role: 'assistant', content: errorText }}
               onRendered={onRendered}
-              role="assistant"
             />
           </div>
         </div>

--- a/src/Conversation.tsx
+++ b/src/Conversation.tsx
@@ -17,12 +17,9 @@ export interface ConversationProps {
   onRendered(): void;
 }
 
-const StreamingTextContent = (message: string, onRendered: () => void) => {
+const StreamingTextContent = (content: string, onRendered: () => void) => {
   return (
-    <Content
-      message={{ role: 'assistant', content: message }}
-      onRendered={onRendered}
-    />
+    <Content message={{ role: 'assistant', content }} onRendered={onRendered} />
   );
 };
 


### PR DESCRIPTION
## Summary

A message of type `ChatCompletionMessageParam` has two properties `role` and `content`. Rather than passing those as separate props from `Conversation` to `Content` components, let's combine them into a single prop.
