### PR TITLE
feat: no horizontal scroll, but don't break apart markdown links

### DIFF
--- a/src/ChatView.module.css
+++ b/src/ChatView.module.css
@@ -155,7 +155,7 @@
   font-weight: inherit;
   line-height: inherit;
   flex: 1;
-  /* 12px works with line-height to center text veritically  in textarea */
+  /* 12px works with line-height to center text vertically  in textarea */
   padding: 12px 55px 10px 20px;
   overflow-y: auto; /* Enable vertical scrolling */
   resize: none; /* Disable manual resizing */

--- a/src/Content.tsx
+++ b/src/Content.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, memo } from 'react';
 import { sanitizeContent } from './sanitize';
 import styles from './ChatView.module.css';
 import { unmaskAddresses } from './utils/chat/unmaskAddresses';
-import { getStoredMasks } from './utils/chat/helpers';
+import { enforceLineBreak, getStoredMasks } from './utils/chat/helpers';
 
 export interface ContentProps {
   content: string;
@@ -30,7 +30,7 @@ export const ContentComponent = ({
 
       try {
         const updatedContent = await sanitizeContent(
-          unmaskAddresses(content, storedMasks.masksToValues),
+          enforceLineBreak(unmaskAddresses(content, storedMasks.masksToValues)),
         );
         if (!cancel) {
           setSanitizedContent(updatedContent);

--- a/src/sanitize.test.ts
+++ b/src/sanitize.test.ts
@@ -116,6 +116,6 @@ This should render anyway
   it("don't render an incomplete markdown link", async () => {
     const input = '[Claude](www.claude.ai';
     const output = await sanitizeContent(input);
-    expect(output).toContain('');
+    expect(output).toMatch('');
   });
 });

--- a/src/utils/chat/helpers.test.ts
+++ b/src/utils/chat/helpers.test.ts
@@ -1,0 +1,22 @@
+import { enforceLineBreak } from './helpers';
+
+describe('enforceLineBreak', () => {
+  test('breaks up a long string', () => {
+    const input = 'A'.repeat(120);
+    const result = enforceLineBreak(input);
+    expect(result).toBe(
+      `${'A'.repeat(45)}<br>${'A'.repeat(45)}<br>${'A'.repeat(30)}`,
+    );
+  });
+  test('shorter strings remain intact', () => {
+    const input = 'A'.repeat(45);
+    const result = enforceLineBreak(input);
+    expect(result).toBe(input);
+  });
+  test('long markdown links remain intact', () => {
+    const input =
+      '[here](https://www.mintscan.io/kava/tx/9492F63D1BBFCAE137A56063C75B27B5A81E8985A4940714173BE06D6562289A)';
+    const result = enforceLineBreak(input);
+    expect(result).toBe(input);
+  });
+});

--- a/src/utils/chat/helpers.ts
+++ b/src/utils/chat/helpers.ts
@@ -21,3 +21,40 @@ export const updateStoredMasks = (
   localStorage.setItem('masksToValues', JSON.stringify(masksToValues));
   localStorage.setItem('valuesToMasks', JSON.stringify(valuesToMasks));
 };
+
+/**
+ * Inserts `<br>` tags into a string at points where a word exceeds a specified length.
+ * This ensures long unbroken words can be wrapped properly in HTML.
+ *
+ * @param {string} text - The input string to process.
+ * @param {number} [maxWordLength=45] - The maximum allowed length of a word before breaking. Slightly longer than 0x addresses
+ * @returns {string} - The processed string with `<wbr>` tags inserted at appropriate points.
+ */
+export const enforceLineBreak = (
+  text: string,
+  maxWordLength: number = 45,
+): string => {
+  if (text.length <= maxWordLength) return text;
+
+  // Early return if text contains a markdown link
+  if (text.match(/\[([^\]]+)\]\(([^)]+)\)/)) {
+    return text;
+  }
+
+  const words = text.split(' ');
+  return words
+    .map((word) => {
+      // If the word length exceeds maxWordLength
+      if (word.length > maxWordLength) {
+        // Split the word into chunks of maxWordLength
+        const chunks = [];
+        for (let i = 0; i < word.length; i += maxWordLength) {
+          chunks.push(word.slice(i, i + maxWordLength));
+        }
+        // Join chunks with <br>
+        return chunks.join('<br>');
+      }
+      return word;
+    })
+    .join(' ');
+};

--- a/src/utils/chat/helpers.ts
+++ b/src/utils/chat/helpers.ts
@@ -44,14 +44,11 @@ export const enforceLineBreak = (
   const words = text.split(' ');
   return words
     .map((word) => {
-      // If the word length exceeds maxWordLength
       if (word.length > maxWordLength) {
-        // Split the word into chunks of maxWordLength
         const chunks = [];
         for (let i = 0; i < word.length; i += maxWordLength) {
           chunks.push(word.slice(i, i + maxWordLength));
         }
-        // Join chunks with <br>
         return chunks.join('<br>');
       }
       return word;


### PR DESCRIPTION
## Summary

Reimplements #142 but without breaking apart markdown links (like the hash link returned from a successful tx)
