### PR TITLE
style: prevent horizontal scroll for assistant messages

### DIFF
--- a/src/components/ChatView.module.css
+++ b/src/components/ChatView.module.css
@@ -66,7 +66,7 @@
   padding: var(--spacing-md);
   margin-left: auto;
   margin-top: var(--borderRadius-sm);
-  max-width: 90%;
+  max-width: 80%;
 }
 
 .left {
@@ -81,6 +81,7 @@
 
 .assistantContainer {
   margin-top: var(--spacing-md);
+  max-width: 80%;
 }
 
 #progressStream {


### PR DESCRIPTION
## Summary

Make both assistant and user classes max width 80% so they break to the next line instead of creating horizontal scroll

## Before

https://github.com/user-attachments/assets/82b46d1b-4451-4cc7-a3f5-ed77a29085e7



## After

https://github.com/user-attachments/assets/3e23dbaf-e02a-45d2-8636-2841a7e1b0cd


 
