### PR TITLE
feat: add chain name to tx confirmation details

### DIFF
--- a/src/config/chainsRegistry.ts
+++ b/src/config/chainsRegistry.ts
@@ -195,7 +195,7 @@ export const chainNameToolCallParam = {
   name: 'chainName',
   type: 'string',
   description:
-    'name of the chain the user is interacting with, if not specified by the user assume kavaEVM',
+    'name of the chain the user is interacting with, if not specified by the user assume Kava EVM',
   enum: [
     ...Object.keys(chainRegistry[ChainType.EVM]),
     ...Object.keys(chainRegistry[ChainType.COSMOS]),

--- a/src/config/prompts/defaultPrompts.ts
+++ b/src/config/prompts/defaultPrompts.ts
@@ -37,13 +37,32 @@ You also handle operational tasks tied to tool calls, ensuring all necessary inf
 **User**: "What is my Kava balance?"
 **Assistant**: *Call the relevant tool to check the balance and respond with real-time data.*
 
-**Transactional Query (e.g., EvmTransferMessage)**:
+**General Query**:
+**User**: "What is my USDT balance on Ethereum?"
+**Assistant**: *Call the relevant tool to check the balance and respond with real-time data.*
+
+**Transactional Message (e.g., EvmTransferMessage)**:
 **User**: "Send 100 USDT to address_1"
 **Assistant**: 
 "I have collected the following information:  
 - Receiving Address: address_1  
 - Token: USD₮  
 - Amount: 100  
+- Chain: Kava EVM
+Is everything correct?"
+
+**User**: "Yes"  
+**Assistant**: *Call the \`EvmTransferMessage.\` function with the collected data.*
+
+
+**Transactional Message (e.g., EvmTransferMessage)**:
+**User**: "Send 100 USDT to address_1 on Ethereum"
+**Assistant**: 
+"I have collected the following information:  
+- Receiving Address: address_1  
+- Token: USD₮  
+- Amount: 100  
+- Chain: Ethereum
 Is everything correct?"
 
 **User**: "Yes"  


### PR DESCRIPTION
## Summary
Addresses Issue #194 

- added examples of transacting with other chains
- made the chain name a part of all tx details 

Example issue
User: Send 1 USDT to ...
Assistant: Can you please specify which chain?


## Demo 

https://github.com/user-attachments/assets/1365699e-6bbe-4435-a2cb-d1642a9ca018



