### PR TITLE
fix: validate users balances before transfer

### DIFF
--- a/src/context/AppContextProvider.tsx
+++ b/src/context/AppContextProvider.tsx
@@ -120,7 +120,8 @@ export const AppContextProvider = ({
         await walletStore.metamaskSwitchNetwork(chainName);
       }
 
-      if (!operation.validate(params, walletStore)) {
+      const validatedParams = await operation.validate(params, walletStore);
+      if (!validatedParams) {
         throw new Error('Invalid parameters for operation');
       }
 

--- a/src/context/AppContextProvider.tsx
+++ b/src/context/AppContextProvider.tsx
@@ -121,6 +121,7 @@ export const AppContextProvider = ({
       }
 
       const validatedParams = await operation.validate(params, walletStore);
+
       if (!validatedParams) {
         throw new Error('Invalid parameters for operation');
       }

--- a/src/services/chain/messages/evm/transfer.ts
+++ b/src/services/chain/messages/evm/transfer.ts
@@ -161,7 +161,6 @@ export class EvmTransferMessage implements ChainMessage<SendToolParams> {
     params: SendToolParams,
     walletStore: WalletStore,
   ): Promise<string> {
-    console.log('calling build transaction');
     const { toAddress, amount, denom } = params;
 
     const { erc20Contracts, rpcUrls, nativeToken } =

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -33,7 +33,7 @@ export interface ChainOperation<T> {
   walletMustMatchChainID?: boolean;
 
   /** Validates the provided parameters match requirements */
-  validate(params: T, walletStore: WalletStore): boolean;
+  validate(params: T, walletStore: WalletStore): boolean | Promise<boolean>;
 
   /** Optional React component that displays as the model is streaming the tool call arguments */
   inProgressComponent?: () => React.FunctionComponent<{


### PR DESCRIPTION
## Summary
- adds a private method to EvmTransferMessage for validating that a user has enough of a particular denom (on a particular chain) 
- calls this message as part of the validation check


## Before

https://github.com/user-attachments/assets/d9b02f98-ffb7-4af7-9563-cdc3db99a15b



## After

https://github.com/user-attachments/assets/dd19b92e-36b1-4ab7-b646-1a6005e0304d


## Follow ons
- After this, we should refactor the `inProgressComponent` to only render if the `validate` method succeeds. Right now, it shows that the tx is in progress, but then the validation fails and it goes away

