### PR TITLE
fix: throw errors from validate step

### DIFF
--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -98,7 +98,7 @@ export async function retryClick(
   }
 }
 
-export async function confirmMetamaskConnection(
+export async function retryConnectClick(
   metamaskPopup: Page | Frame,
   { timeout = 60000, interval = 500 } = {},
 ): Promise<void> {
@@ -109,15 +109,28 @@ export async function confirmMetamaskConnection(
   );
 }
 
-export async function confirmMetamaskTransaction(
+export async function retryConnectAndConfirm(
   metamaskPopup: Page | Frame,
   { timeout = 60000, interval = 500 } = {},
 ): Promise<void> {
-  await confirmMetamaskConnection(metamaskPopup, { timeout, interval });
+  await retryConnectClick(metamaskPopup, { timeout, interval });
 
   await retryClick(
     metamaskPopup,
     { role: 'button', name: 'Confirm' },
+    { timeout, interval },
+  );
+}
+
+export async function retryConnectAndApprove(
+  metamaskPopup: Page | Frame,
+  { timeout = 60000, interval = 500 } = {},
+): Promise<void> {
+  await retryConnectClick(metamaskPopup, { timeout, interval });
+
+  await retryClick(
+    metamaskPopup,
+    { role: 'button', name: 'Approve' },
     { timeout, interval },
   );
 }

--- a/src/services/chain/messages/evm/transfer.ts
+++ b/src/services/chain/messages/evm/transfer.ts
@@ -99,7 +99,6 @@ export class EvmTransferMessage implements ChainMessage<SendToolParams> {
 
     return true;
   }
-
   async buildTransaction(
     params: SendToolParams,
     walletStore: WalletStore,


### PR DESCRIPTION
## Summary
The context-level callback `executeOperation` now has a try-catch block so that we can `setErrorText` with the explicit error. This way, we can provide useful feedback to the user on why their tx couldn't go through.

## Before
UI error doesn't help

https://github.com/user-attachments/assets/af3c3fad-a2e3-43ec-9abd-feb6e7b804dc

And no error is thrown in the console

![Screenshot 2025-01-28 at 4 20 38 PM](https://github.com/user-attachments/assets/4d294f98-eb12-4165-ac75-75cc4017750f)



## After
We should probably do a follow-on to address/remove the "double error" treatment

Perhaps if we receive a response from a failed tool call, 
- don't add it to the message store 
- don't render it to the UI

https://github.com/user-attachments/assets/ace274f6-2dbc-46ff-800e-cd5a0fa5a4bc

