### PR TITLE
fix: don't show in progress until validation passes

### DIFF
--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -109,11 +109,11 @@ describe('chat', () => {
     //  Confirm the tx
     await chat.submitMessage('Yes');
 
-    //  In progress
-    await expect(page.getByTestId('in-progress-tx-display')).toBeVisible();
-
     const metamaskPopup = await metamaskPopupPromise;
     await confirmMetamaskTransaction(metamaskPopup);
+
+    //  In progress
+    await expect(page.getByTestId('in-progress-tx-display')).toBeVisible();
 
     const provider = new ethers.JsonRpcProvider(
       'https://evm.data.internal.testnet.us-east.production.kava.io',
@@ -153,11 +153,11 @@ describe('chat', () => {
     //  Confirm the tx
     await chat.submitMessage('Yes');
 
-    //  In progress
-    await expect(page.getByTestId('in-progress-tx-display')).toBeVisible();
-
     const metamaskPopup = await metamaskPopupPromise;
     await confirmMetamaskTransaction(metamaskPopup);
+
+    //  In progress
+    await expect(page.getByTestId('in-progress-tx-display')).toBeVisible();
 
     const provider = new ethers.JsonRpcProvider(
       'https://evm.data.internal.testnet.us-east.production.kava.io',

--- a/src/components/ConnectWalletPrompt.tsx
+++ b/src/components/ConnectWalletPrompt.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useSyncExternalStore } from 'react';
+import { ToolCallStream } from '../toolCallStreamStore';
+import { useAppContext } from '../context/useAppContext';
+import { useScrollToBottom } from '../useScrollToBottom';
+
+export const ConnectWalletPrompt = ({
+  onRendered,
+}: {
+  toolCall: ToolCallStream;
+  onRendered?: () => void;
+}) => {
+  const { progressStore } = useAppContext();
+
+  const progressText = useSyncExternalStore(
+    progressStore.subscribe,
+    progressStore.getSnapshot,
+  );
+
+  useEffect(() => {
+    progressStore.setText('Connect your wallet to continue');
+    return () => {
+      progressStore.setText('');
+    };
+  }, [progressStore, progressText]);
+
+  useScrollToBottom(onRendered);
+
+  return null;
+};

--- a/src/components/InProgressTxDisplay.tsx
+++ b/src/components/InProgressTxDisplay.tsx
@@ -1,6 +1,7 @@
 import { ToolCallStream } from '../toolCallStreamStore';
 import styles from './TxDisplay.module.css';
 import { useScrollToBottom } from '../useScrollToBottom';
+import { useAppContext } from '../context/useAppContext';
 
 export const InProgressTxDisplay = ({
   onRendered,
@@ -9,6 +10,12 @@ export const InProgressTxDisplay = ({
   onRendered?: () => void;
 }) => {
   useScrollToBottom(onRendered);
+
+  const { isValidated } = useAppContext();
+
+  if (!isValidated) {
+    return null;
+  }
 
   return (
     <div

--- a/src/components/InProgressTxDisplay.tsx
+++ b/src/components/InProgressTxDisplay.tsx
@@ -11,9 +11,9 @@ export const InProgressTxDisplay = ({
 }) => {
   useScrollToBottom(onRendered);
 
-  const { isValidated } = useAppContext();
+  const { isOperationValidated } = useAppContext();
 
-  if (!isValidated) {
+  if (!isOperationValidated) {
     return null;
   }
 

--- a/src/components/InProgressTxDisplay.tsx
+++ b/src/components/InProgressTxDisplay.tsx
@@ -9,9 +9,9 @@ export const InProgressTxDisplay = ({
   toolCall: ToolCallStream;
   onRendered?: () => void;
 }) => {
-  useScrollToBottom(onRendered);
-
   const { isOperationValidated } = useAppContext();
+
+  useScrollToBottom(onRendered, isOperationValidated);
 
   if (!isOperationValidated) {
     return null;

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -26,7 +26,7 @@ export type AppContextType = {
   toolCallStreamStore: ToolCallStreamStore;
   progressStore: TextStreamStore;
   messageHistoryStore: MessageHistoryStore;
-  isValidated: boolean;
+  isOperationValidated: boolean;
 };
 
 export const AppContext = createContext<AppContextType | undefined>(undefined);

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -19,15 +19,14 @@ export type AppContextType = {
   isRequesting: boolean;
   setIsRequesting: React.Dispatch<React.SetStateAction<boolean>>;
   registry: OperationRegistry<unknown>;
-
   getOpenAITools: () => ChatCompletionTool[];
   executeOperation: ExecuteOperation;
-
   walletStore: WalletStore;
   messageStore: TextStreamStore;
   toolCallStreamStore: ToolCallStreamStore;
   progressStore: TextStreamStore;
   messageHistoryStore: MessageHistoryStore;
+  isValidated: boolean;
 };
 
 export const AppContext = createContext<AppContextType | undefined>(undefined);

--- a/src/context/AppContextProvider.tsx
+++ b/src/context/AppContextProvider.tsx
@@ -73,11 +73,12 @@ export const AppContextProvider = ({
    */
   const executeOperation = useCallback(
     async (operationName: string, params: unknown) => {
+      setIsOperationValidated(false);
+
       const operation = registry.get(operationName);
       if (!operation) {
         throw new Error(`Unknown operation type: ${operationName}`);
       }
-      setIsOperationValidated(false);
 
       let chainId = `0x${Number(2222).toString(16)}`; // default
       let chainName = ChainNames.KAVA_EVM; // default

--- a/src/context/AppContextProvider.tsx
+++ b/src/context/AppContextProvider.tsx
@@ -46,7 +46,7 @@ export const AppContextProvider = ({
   progressStore: TextStreamStore;
   messageHistoryStore: MessageHistoryStore;
 }) => {
-  const [isValidated, setIsValidated] = useState(false);
+  const [isOperationValidated, setIsOperationValidated] = useState(false);
   const [errorText, setErrorText] = useState('');
   // use is sending request to signify to the chat view that
   // a request is in progress so it can disable inputs
@@ -77,7 +77,7 @@ export const AppContextProvider = ({
       if (!operation) {
         throw new Error(`Unknown operation type: ${operationName}`);
       }
-      setIsValidated(false);
+      setIsOperationValidated(false);
 
       let chainId = `0x${Number(2222).toString(16)}`; // default
       let chainName = ChainNames.KAVA_EVM; // default
@@ -127,7 +127,7 @@ export const AppContextProvider = ({
       if (!validatedParams) {
         throw new Error('Invalid parameters for operation');
       }
-      setIsValidated(true);
+      setIsOperationValidated(true);
       if ('buildTransaction' in operation) {
         return (operation as ChainMessage<unknown>).buildTransaction(
           params,
@@ -162,7 +162,7 @@ export const AppContextProvider = ({
         setIsReady,
         isRequesting,
         setIsRequesting,
-        isValidated,
+        isOperationValidated,
       }}
     >
       {children}

--- a/src/context/AppContextProvider.tsx
+++ b/src/context/AppContextProvider.tsx
@@ -46,6 +46,7 @@ export const AppContextProvider = ({
   progressStore: TextStreamStore;
   messageHistoryStore: MessageHistoryStore;
 }) => {
+  const [isValidated, setIsValidated] = useState(false);
   const [errorText, setErrorText] = useState('');
   // use is sending request to signify to the chat view that
   // a request is in progress so it can disable inputs
@@ -76,6 +77,7 @@ export const AppContextProvider = ({
       if (!operation) {
         throw new Error(`Unknown operation type: ${operationName}`);
       }
+      setIsValidated(false);
 
       let chainId = `0x${Number(2222).toString(16)}`; // default
       let chainName = ChainNames.KAVA_EVM; // default
@@ -125,7 +127,7 @@ export const AppContextProvider = ({
       if (!validatedParams) {
         throw new Error('Invalid parameters for operation');
       }
-
+      setIsValidated(true);
       if ('buildTransaction' in operation) {
         return (operation as ChainMessage<unknown>).buildTransaction(
           params,
@@ -151,17 +153,16 @@ export const AppContextProvider = ({
         progressStore,
         walletStore,
         toolCallStreamStore,
-
         getOpenAITools,
         executeOperation,
         registry,
-
         errorText,
         setErrorText,
         isReady,
         setIsReady,
         isRequesting,
         setIsRequesting,
+        isValidated,
       }}
     >
       {children}

--- a/src/services/chain/messages/evm/transfer.ts
+++ b/src/services/chain/messages/evm/transfer.ts
@@ -16,6 +16,7 @@ import {
   chainNameToolCallParam,
   chainRegistry,
 } from '../../../../config/chainsRegistry';
+import { ConnectWalletPrompt } from '../../../../components/ConnectWalletPrompt';
 
 interface SendToolParams {
   chainName: string;
@@ -31,6 +32,7 @@ export class EvmTransferMessage implements ChainMessage<SendToolParams> {
   chainType = ChainType.EVM;
   needsWallet = [WalletTypes.METAMASK];
   walletMustMatchChainID = true;
+  private hasValidWallet = false;
 
   parameters = [
     chainNameToolCallParam,
@@ -55,7 +57,7 @@ export class EvmTransferMessage implements ChainMessage<SendToolParams> {
   ];
 
   inProgressComponent() {
-    return InProgressTxDisplay;
+    return this.hasValidWallet ? InProgressTxDisplay : ConnectWalletPrompt;
   }
 
   private async validateBalance(
@@ -113,6 +115,9 @@ export class EvmTransferMessage implements ChainMessage<SendToolParams> {
         throw new Error('please connect to a compatible wallet');
       }
     }
+
+    //  wallet checks have passed
+    this.hasValidWallet = true;
 
     if (!chainRegistry[this.chainType][params.chainName]) {
       throw new Error(`unknown chain name ${params.chainName}`);

--- a/src/useScrollToBottom.tsx
+++ b/src/useScrollToBottom.tsx
@@ -1,9 +1,12 @@
 import { useEffect } from 'react';
 
-export const useScrollToBottom = (onRendered?: () => void) => {
+export const useScrollToBottom = (
+  onRendered?: () => void,
+  isOperationValidated?: boolean,
+) => {
   useEffect(() => {
     if (onRendered) {
       requestAnimationFrame(onRendered);
     }
-  }, [onRendered]);
+  }, [onRendered, isOperationValidated]);
 };


### PR DESCRIPTION
## Summary
Addresses Issue #203 

## Demo 

### Happy Path

https://github.com/user-attachments/assets/b14488fd-68cb-4de8-a2c1-9dc1ac69be34



### Error Path

https://github.com/user-attachments/assets/5d6ff118-88f1-4c86-9619-b88f41fe9af4



## Follow On
- It would be nice to not render the empty assistant message that's above the in progress card, causing it to not be aligned with the icon
- For the error path, we see "Thinking" ➡️  "{{empty}}" ➡️ "Thinking" ➡️ "{{error text}}" and it would be nice to eliminate those middle two states
