### PR TITLE
fix: harden prompt for chain balances query

### DIFF
--- a/src/config/prompts/defaultPrompts.ts
+++ b/src/config/prompts/defaultPrompts.ts
@@ -38,7 +38,7 @@ You also handle operational tasks tied to tool calls, ensuring all necessary inf
 **Assistant**: *Call the \`EvmBalancesQuery.\` tool to check the balances on Kava EVM (the default chain when none is specified) and respond with real-time data.*
 
 **General Query**:
-**User**: "What are my balances on Ethereum?"
+**User**: "Check my balances on Ethereum"
 **Assistant**: *Call the \`EvmBalancesQuery.\` tool to check the balances on Ethereum and respond with real-time data.*
 
 **Transactional Message (e.g., EvmTransferMessage)**:

--- a/src/config/prompts/defaultPrompts.ts
+++ b/src/config/prompts/defaultPrompts.ts
@@ -34,12 +34,12 @@ You also handle operational tasks tied to tool calls, ensuring all necessary inf
 
 #### Example Interactions:
 **General Query**:
-**User**: "What is my Kava balance?"
-**Assistant**: *Call the relevant tool to check the balance and respond with real-time data.*
+**User**: "What are my balances?"
+**Assistant**: *Call the \`EvmBalancesQuery.\` tool to check the balances on Kava EVM (the default chain when none is specified) and respond with real-time data.*
 
 **General Query**:
-**User**: "What is my USDT balance on Ethereum?"
-**Assistant**: *Call the relevant tool to check the balance and respond with real-time data.*
+**User**: "What are my balances on Ethereum?"
+**Assistant**: *Call the \`EvmBalancesQuery.\` tool to check the balances on Ethereum and respond with real-time data.*
 
 **Transactional Message (e.g., EvmTransferMessage)**:
 **User**: "Send 100 USDT to address_1"
@@ -79,4 +79,5 @@ Is everything correct?"
 - Modularize responses so they apply to any tool (e.g., balances, send transaction).
 - Retain session context to handle multi-step tasks seamlessly without redundancy.
 - If a user provides an address mask (i.e. 'address_2), do not ask them for a valid ethereum address - the mask will be converted to an address later in the process.
+- If a user queries their balances and doesn't specify a chain, assume they mean Kava EVM and don't ask them to confirm which chain.
 `;


### PR DESCRIPTION
## Summary
A few times, when I asked "What are my balances" I got a response of "What chain do you want to check?" so the model wasn't quite clear on the concept of a default if not specified.

Also, I adjusted our examples to include clearer examples. If you ask for your USDt balance on Kava, we currently return all of your balances, not just the specified one.

## Demo 
Got it right 4/4

https://github.com/user-attachments/assets/6a70988b-3ce5-47e6-ac3b-0af34980bf28

