### PR TITLE
fix: don't display asset if balance fetching failed

### DIFF
--- a/src/services/chain/queries/evm/evmBalances.ts
+++ b/src/services/chain/queries/evm/evmBalances.ts
@@ -92,7 +92,10 @@ export class EvmBalancesQuery implements ChainQuery<EvmBalanceQueryParams> {
 
           return `${displayName}: ${formattedBalance}`;
         } catch (err) {
-          return `${displayName}: failed to fetch balance ${JSON.stringify(err)}`;
+          console.error(
+            `failed to fetch balance for ${displayName}: ${JSON.stringify(err)}`,
+          );
+          return '';
         }
       });
     }


### PR DESCRIPTION
## Summary

If there's an error fetching contract balances (occurring because we have a hardcoded list that don't exist in all env's), log the error to the console, but don't display the error in the UI, simply skip and move on.

![Screenshot 2025-01-29 at 5 05 40 PM](https://github.com/user-attachments/assets/28730b44-cfe1-4376-9783-e1c631138a19)


