### PR TITLE
feat: cleanup balances display card styles

### DIFF
--- a/src/components/displayCards/DisplayCards.module.css
+++ b/src/components/displayCards/DisplayCards.module.css
@@ -115,7 +115,8 @@
 .balanceRow {
   display: flex;
   flex-direction: column;
-  padding: var(--spacing-sm) var(--spacing-md);
+  justify-content: center;
+  padding: var(--spacing-xs) var(--spacing-md);
   background-color: var(--colors-bgSecondary);
   border-radius: var(--borderRadius-sm);
   border: 1px solid var(--colors-bgQuaternary);
@@ -124,10 +125,12 @@
 .assetName {
   font-weight: var(--typography-fontWeightBold);
   color: var(--colors-textMuted);
+  font-size: 1.35rem;
 }
 
 .assetAmount {
   color: var(--color-textPrimary);
   margin-top: var(--spacing-xs);
   word-break: break-all;
+  font-size: 1.15rem;
 }


### PR DESCRIPTION
## Summary
- Fixes some spacing issues when balances are long by lowering the font-size a bit for the amount
- Adjusts the denom font size since it now looks out of place with the smaller amount font size
- adjusts some of the spacing in the cards to make sure items are centered and with less padding

## Demo 

## Open Questions

## Follow-on tasks
