### PR TITLE
ci: implement button click retries in metamask workflow

### DIFF
--- a/e2e/Metamask.ts
+++ b/e2e/Metamask.ts
@@ -1,4 +1,4 @@
-import { expect } from './fixtures';
+import { expect, retryButtonClick } from './fixtures';
 import { BrowserContext, Page } from '@playwright/test';
 import { SigningOptions, TxType, Wallet, WalletOpts } from './Wallet';
 
@@ -165,38 +165,49 @@ export class MetaMask extends Wallet {
       timeout: 10000,
     });
 
-    await metaMaskPage.getByTestId('network-display').click();
-    await metaMaskPage
-      .getByRole('button', { name: 'Add a custom network' })
-      .click();
+    await retryButtonClick(metaMaskPage, { 'data-testid': 'network-display' });
+    await retryButtonClick(metaMaskPage, {
+      name: 'Add a custom network',
+    });
 
     await metaMaskPage
       .getByTestId('network-form-network-name')
       .fill('Kava Internal Testnet');
-    await metaMaskPage.getByTestId('test-add-rpc-drop-down').click();
-    await metaMaskPage.getByRole('button', { name: 'Add RPC URL' }).click();
+
+    await retryButtonClick(metaMaskPage, {
+      'data-testid': 'test-add-rpc-drop-down',
+    });
+    await retryButtonClick(metaMaskPage, { name: 'Add RPC URL' });
+
     await metaMaskPage
       .getByTestId('rpc-url-input-test')
       .fill('https://evm.data.internal.testnet.us-east.production.kava.io');
-    await metaMaskPage.getByRole('button', { name: 'Add URL' }).click();
+
+    await retryButtonClick(metaMaskPage, { name: 'Add URL' });
     await metaMaskPage.getByTestId('network-form-chain-id').fill('2221');
     await metaMaskPage.getByTestId('network-form-ticker-input').fill('TKAVA');
-
-    await metaMaskPage.getByRole('button', { name: 'Save' }).click();
+    await retryButtonClick(metaMaskPage, { name: 'Save' });
     await metaMaskPage.waitForTimeout(2000);
 
-    await metaMaskPage.getByTestId('network-display').click();
-    await metaMaskPage.getByTestId('Kava Internal Testnet').click();
+    await retryButtonClick(metaMaskPage, { 'data-testid': 'network-display' });
+    await retryButtonClick(metaMaskPage, {
+      'data-testid': 'Kava Internal Testnet',
+    });
 
-    await metaMaskPage.getByTestId('account-menu-icon').click();
+    await retryButtonClick(metaMaskPage, {
+      'data-testid': 'account-menu-icon',
+    });
 
-    await metaMaskPage
-      .getByRole('button', { name: 'Add account or hardware wallet' })
-      .click();
-    await metaMaskPage.getByRole('button', { name: 'Import account' }).click();
+    await retryButtonClick(metaMaskPage, {
+      name: 'Add account or hardware wallet',
+    });
+
+    await retryButtonClick(metaMaskPage, { name: 'Import account' });
 
     await metaMaskPage.locator('#private-key-box').fill(E2E_WALLET_KEY);
-    await metaMaskPage.getByRole('button', { name: 'Import' }).click();
+
+    await retryButtonClick(metaMaskPage, { name: 'Import' });
+
     await metaMaskPage.close();
   }
 }

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -1,10 +1,4 @@
-import {
-  describe,
-  expect,
-  test,
-  confirmMetamaskTransaction,
-  confirmMetamaskConnection,
-} from './fixtures';
+import { describe, expect, test, retryClick } from './fixtures';
 import { Chat } from './Chat';
 import { MetaMask } from './Metamask';
 import { ethers } from 'ethers';
@@ -67,7 +61,8 @@ describe('chat', () => {
     await chat.waitForStreamToFinish();
 
     const metamaskPopup = await metamaskPopupPromise;
-    await confirmMetamaskConnection(metamaskPopup);
+
+    await retryClick(metamaskPopup, { role: 'button', name: 'Connect' });
 
     await chat.waitForStreamToFinish();
     await chat.waitForAssistantResponse();
@@ -104,7 +99,8 @@ describe('chat', () => {
     await chat.waitForStreamToFinish();
 
     const metamaskPopup = await metamaskPopupPromise;
-    await confirmMetamaskTransaction(metamaskPopup);
+    await retryClick(metamaskPopup, { role: 'button', name: 'Connect' });
+    await retryClick(metamaskPopup, { role: 'button', name: 'Confirm' });
 
     //  In progress
     await expect(page.getByTestId('in-progress-tx-display')).toBeVisible();
@@ -145,7 +141,8 @@ describe('chat', () => {
     await chat.waitForStreamToFinish();
 
     const metamaskPopup = await metamaskPopupPromise;
-    await confirmMetamaskTransaction(metamaskPopup);
+    await retryClick(metamaskPopup, { role: 'button', name: 'Connect' });
+    await retryClick(metamaskPopup, { role: 'button', name: 'Confirm' });
 
     //  In progress
     await expect(page.getByTestId('in-progress-tx-display')).toBeVisible();

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, retryClick } from './fixtures';
+import { describe, expect, test, retryButtonClick } from './fixtures';
 import { Chat } from './Chat';
 import { MetaMask } from './Metamask';
 import { ethers } from 'ethers';
@@ -62,7 +62,7 @@ describe('chat', () => {
 
     const metamaskPopup = await metamaskPopupPromise;
 
-    await retryClick(metamaskPopup, { role: 'button', name: 'Connect' });
+    await retryButtonClick(metamaskPopup, { role: 'button', name: 'Connect' });
 
     await chat.waitForStreamToFinish();
     await chat.waitForAssistantResponse();
@@ -99,8 +99,8 @@ describe('chat', () => {
     await chat.waitForStreamToFinish();
 
     const metamaskPopup = await metamaskPopupPromise;
-    await retryClick(metamaskPopup, { role: 'button', name: 'Connect' });
-    await retryClick(metamaskPopup, { role: 'button', name: 'Confirm' });
+    await retryButtonClick(metamaskPopup, { role: 'button', name: 'Connect' });
+    await retryButtonClick(metamaskPopup, { role: 'button', name: 'Confirm' });
 
     //  In progress
     await expect(page.getByTestId('in-progress-tx-display')).toBeVisible();
@@ -141,8 +141,8 @@ describe('chat', () => {
     await chat.waitForStreamToFinish();
 
     const metamaskPopup = await metamaskPopupPromise;
-    await retryClick(metamaskPopup, { role: 'button', name: 'Connect' });
-    await retryClick(metamaskPopup, { role: 'button', name: 'Confirm' });
+    await retryButtonClick(metamaskPopup, { role: 'button', name: 'Connect' });
+    await retryButtonClick(metamaskPopup, { role: 'button', name: 'Confirm' });
 
     //  In progress
     await expect(page.getByTestId('in-progress-tx-display')).toBeVisible();

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -62,7 +62,7 @@ describe('chat', () => {
 
     const metamaskPopup = await metamaskPopupPromise;
 
-    await retryButtonClick(metamaskPopup, { role: 'button', name: 'Connect' });
+    await retryButtonClick(metamaskPopup, { name: 'Connect' });
 
     await chat.waitForStreamToFinish();
     await chat.waitForAssistantResponse();
@@ -99,8 +99,8 @@ describe('chat', () => {
     await chat.waitForStreamToFinish();
 
     const metamaskPopup = await metamaskPopupPromise;
-    await retryButtonClick(metamaskPopup, { role: 'button', name: 'Connect' });
-    await retryButtonClick(metamaskPopup, { role: 'button', name: 'Confirm' });
+    await retryButtonClick(metamaskPopup, { name: 'Connect' });
+    await retryButtonClick(metamaskPopup, { name: 'Confirm' });
 
     //  In progress
     await expect(page.getByTestId('in-progress-tx-display')).toBeVisible();
@@ -141,8 +141,8 @@ describe('chat', () => {
     await chat.waitForStreamToFinish();
 
     const metamaskPopup = await metamaskPopupPromise;
-    await retryButtonClick(metamaskPopup, { role: 'button', name: 'Connect' });
-    await retryButtonClick(metamaskPopup, { role: 'button', name: 'Confirm' });
+    await retryButtonClick(metamaskPopup, { name: 'Connect' });
+    await retryButtonClick(metamaskPopup, { name: 'Confirm' });
 
     //  In progress
     await expect(page.getByTestId('in-progress-tx-display')).toBeVisible();

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -72,14 +72,14 @@ export const describe = test.describe;
 export const only = test.only;
 export const expect = test.expect;
 
-type ButtonLocator = { role: string; name: string } | { 'data-testid': string };
+type ButtonLocator = { name: string } | { 'data-testid': string };
 
 /**
  * Retries clicking a button that may be flaky in tests
  * @param page - Playwright Page or Frame
- * @param locator - Either a role/name combo or test ID to find the button
+ * @param locator - Either a name or test ID to find the button
  */
-export async function retryClick(
+export async function retryButtonClick(
   page: Page | Frame,
   locator: ButtonLocator,
 ): Promise<void> {

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -72,52 +72,38 @@ export const describe = test.describe;
 export const only = test.only;
 export const expect = test.expect;
 
-const DEFAULT_INTERVAL = 1000; // 1 second
+type ButtonLocator = { role: string; name: string } | { 'data-testid': string };
 
+/**
+ * Retries clicking a button that may be flaky in tests
+ * @param page - Playwright Page or Frame
+ * @param locator - Either a role/name combo or test ID to find the button
+ */
 export async function retryClick(
   page: Page | Frame,
-  buttonOptions: { role: string; name: string },
-  options: { timeout?: number; interval?: number } = {},
+  locator: ButtonLocator,
 ): Promise<void> {
   const MAX_RETRIES = 5;
-  const interval = options.interval || DEFAULT_INTERVAL;
+  const DEFAULT_INTERVAL = 1000;
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const button = await page.getByRole('button', buttonOptions);
-      await button.click({ timeout: interval });
+      const button =
+        'data-testid' in locator
+          ? page.getByTestId(locator['data-testid'])
+          : page.getByRole('button', locator);
+
+      await button.click({ timeout: DEFAULT_INTERVAL });
       return;
     } catch (error) {
       if (attempt === MAX_RETRIES - 1) {
+        const identifier =
+          'data-testid' in locator ? locator['data-testid'] : locator.name;
         throw new Error(
-          `Failed to click button "${buttonOptions.name}" after ${MAX_RETRIES} attempts: ${error.message}`,
+          `Failed to click button "${identifier}" after ${MAX_RETRIES} attempts: ${error.message}`,
         );
       }
-      await page.waitForTimeout(interval);
+      await page.waitForTimeout(DEFAULT_INTERVAL);
     }
   }
-}
-
-export async function confirmMetamaskConnection(
-  metamaskPopup: Page | Frame,
-  { timeout = 60000, interval = 500 } = {},
-): Promise<void> {
-  await retryClick(
-    metamaskPopup,
-    { role: 'button', name: 'Connect' },
-    { timeout, interval },
-  );
-}
-
-export async function confirmMetamaskTransaction(
-  metamaskPopup: Page | Frame,
-  { timeout = 60000, interval = 500 } = {},
-): Promise<void> {
-  await confirmMetamaskConnection(metamaskPopup, { timeout, interval });
-
-  await retryClick(
-    metamaskPopup,
-    { role: 'button', name: 'Confirm' },
-    { timeout, interval },
-  );
 }


### PR DESCRIPTION
## Summary
Metamask-related test can be flaky since we are relying on different pop ups. Retrying button clicks seems to work for certain stages of the process, so let's propagate that to all button clicks within the metamask workflow.

