### PR TITLE
feat: decouple masking with core chat components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,8 @@ import { ToolCallStreamStore } from './core/stores/toolCallStreamStore';
 import { MessageHistoryStore } from './core/stores/messageHistoryStore';
 import { useAppContext } from './context/useAppContext';
 import { OperationResult } from './features/blockchain/types/chain';
-import { ExecuteOperation, ModelConfig } from './context/types';
+import { ExecuteOperation } from './context/types';
+import { ModelConfig } from './services/modelRegistry';
 
 let client: OpenAI | null = null;
 

--- a/src/components/ChatView.test.tsx
+++ b/src/components/ChatView.test.tsx
@@ -5,7 +5,7 @@ import { AppContextProvider } from '../context/AppContextProvider';
 import { TextStreamStore } from '../core/stores/textStreamStore';
 import { ToolCallStreamStore } from '../core/stores/toolCallStreamStore';
 import { MessageHistoryStore } from '../core/stores/messageHistoryStore';
-import { WalletStore } from '../features/blockchain/stores//walletStore';
+import { WalletStore } from '../features/blockchain/stores/walletStore';
 const messageStore = new TextStreamStore();
 const progressStore = new TextStreamStore();
 const toolCallStreamStore = new ToolCallStreamStore();

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -4,8 +4,6 @@ import { CancelChatIcon, ResetChatIcon, SendChatIcon } from '../shared/assets';
 import { useTheme } from '../shared/theme/useTheme';
 import { Conversation } from './Conversation';
 import type { ChatCompletionMessageParam } from 'openai/resources/index';
-import { maskAddresses } from '../utils/chat/maskAddresses';
-import { getStoredMasks, updateStoredMasks } from '../utils/chat/helpers';
 import { useAppContext } from '../context/useAppContext';
 
 export interface ChatViewProps {
@@ -25,7 +23,7 @@ export const ChatView = ({
   onCancel,
   introText,
 }: ChatViewProps) => {
-  const { isRequesting } = useAppContext();
+  const { modelConfig, isRequesting } = useAppContext();
   const hasMessages =
     messages.filter((message) => message.role != 'system').length > 0;
 
@@ -55,28 +53,24 @@ export const ChatView = ({
     [],
   );
 
-  const handleButtonClick = useCallback(() => {
+  const handleButtonClick = useCallback(async () => {
     if (isRequesting) {
       onCancel();
       return;
     }
 
-    if (inputValue == '') {
+    if (inputValue === '') {
       return;
     }
 
-    const storedMasks = getStoredMasks();
-    const { output, masksToValues, valuesToMasks } = maskAddresses(
-      inputValue,
-      storedMasks.valuesToMasks,
-      storedMasks.masksToValues,
-    );
+    let processedMessage = inputValue;
+    if (modelConfig.messageProcessors?.preProcess) {
+      processedMessage = modelConfig.messageProcessors.preProcess(inputValue);
+    }
 
-    updateStoredMasks(masksToValues, valuesToMasks);
-
-    onSubmit(output);
+    onSubmit(processedMessage);
     setInputValue('');
-  }, [isRequesting, inputValue, onSubmit, onCancel]);
+  }, [isRequesting, inputValue, onSubmit, onCancel, modelConfig]);
 
   const buttonRef = useRef<HTMLButtonElement>(null);
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/src/context/AppContextProvider.tsx
+++ b/src/context/AppContextProvider.tsx
@@ -7,10 +7,10 @@ import { ToolCallStreamStore } from '../core/stores/toolCallStreamStore';
 import { MessageHistoryStore } from '../core/stores/messageHistoryStore';
 import {
   MODEL_REGISTRY,
+  ModelConfig,
   SupportedBlockchainModels,
   SupportedReasoningModels,
 } from '../services/modelRegistry';
-import { ModelConfig } from './types';
 import { initializeMessageRegistry } from './initializeMessageRegistry';
 import { useExecuteOperation } from './useExecuteOperation';
 

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -1,10 +1,10 @@
-import type { ChatCompletionTool } from 'openai/resources/index';
 import { OperationRegistry } from '../features/blockchain/services/registry';
 import { WalletStore } from '../features/blockchain/stores/walletStore';
 import { TextStreamStore } from '../core/stores/textStreamStore';
 import { ToolCallStreamStore } from '../core/stores/toolCallStreamStore';
 import { MessageHistoryStore } from '../core/stores/messageHistoryStore';
 import {
+  ModelConfig,
   SupportedBlockchainModels,
   SupportedReasoningModels,
 } from '../services/modelRegistry';
@@ -34,11 +34,3 @@ export type AppContextType = {
   messageHistoryStore: MessageHistoryStore;
   isOperationValidated: boolean;
 };
-
-export interface ModelConfig {
-  name: string;
-  description: string;
-  tools: ChatCompletionTool[];
-  systemPrompt: string;
-  introText: string;
-}

--- a/src/features/blockchain/services/messageProcessing.ts
+++ b/src/features/blockchain/services/messageProcessing.ts
@@ -1,0 +1,32 @@
+import { getStoredMasks, updateStoredMasks } from '../../../utils/chat/helpers';
+import { maskAddresses } from '../../../utils/chat/maskAddresses';
+import { unmaskAddresses } from '../../../utils/chat/unmaskAddresses';
+
+export const blockchainMessageProcessor = {
+  /**
+   * Pre-processes outgoing messages by masking Ethereum addresses
+   * Updates the stored masks in local storage
+   */
+  preProcess: (message: string): string => {
+    const storedMasks = getStoredMasks();
+    const { output, masksToValues, valuesToMasks } = maskAddresses(
+      message,
+      storedMasks.valuesToMasks,
+      storedMasks.masksToValues,
+    );
+
+    // Update stored masks with any new mappings
+    updateStoredMasks(masksToValues, valuesToMasks);
+
+    return output;
+  },
+
+  /**
+   * Post-processes incoming messages by unmasking Ethereum addresses
+   * Uses the stored masks from local storage
+   */
+  postProcess: (message: string): string => {
+    const storedMasks = getStoredMasks();
+    return unmaskAddresses(message, storedMasks.masksToValues);
+  },
+};

--- a/src/services/modelRegistry.ts
+++ b/src/services/modelRegistry.ts
@@ -15,11 +15,12 @@ import {
 } from '../features/blockchain/components/displayCards';
 import { InProgressTxDisplayProps } from '../features/blockchain/components/displayCards/InProgressTxDisplay';
 import { CompleteQueryDisplayProps } from '../features/blockchain/components/displayCards/CompleteQueryDisplay';
+import { blockchainMessageProcessor } from '../features/blockchain/services/messageProcessing';
 
 export type SupportedBlockchainModels = 'gpt-4o' | 'gpt-4o-mini';
 export type SupportedReasoningModels = 'deepseek-chat';
 
-interface ModelConfig {
+export interface ModelConfig {
   name: SupportedBlockchainModels | SupportedReasoningModels;
   description: string;
   tools: ChatCompletionTool[];
@@ -34,6 +35,10 @@ interface ModelConfig {
       inProgress: ComponentType<InProgressQueryProps>;
       complete: ComponentType<CompleteQueryDisplayProps>;
     };
+  };
+  messageProcessors?: {
+    preProcess?: (message: string) => string;
+    postProcess?: (message: string) => string;
   };
 }
 
@@ -63,6 +68,7 @@ export const MODEL_REGISTRY: ModelRegistry = {
           complete: CompleteQueryDisplay,
         },
       },
+      messageProcessors: blockchainMessageProcessor,
     },
     'gpt-4o-mini': {
       name: 'gpt-4o-mini',


### PR DESCRIPTION
Since masking is currently tied heavily to the 0x address process, get it out of the core chat components in favor or pre or post processing "hooks"

## Summary

## Demo 

## Open Questions

## Follow-on tasks
