### PR TITLE
feat: handle disabled states for dropdown

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -86,6 +86,7 @@ jobs:
       VITE_E2E_WALLET_KEY: ${{ secrets.VITE_E2E_WALLET_KEY }}
       VITE_E2E_WALLET_MNEMONIC: ${{ secrets.VITE_E2E_WALLET_MNEMONIC }}
       VITE_E2E_WALLET_ADDRESS: ${{ secrets.VITE_E2E_WALLET_ADDRESS }}
+      VITE_FEAT_UPDATED_DESIGN: true
     outputs:
       changed: ${{ steps.diff.outputs.diff != '' }}
       image-name: ${{ steps.image-name.outputs.image }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,6 +16,7 @@ jobs:
       VITE_E2E_WALLET_KEY: ${{ secrets.VITE_E2E_WALLET_KEY }}
       VITE_E2E_WALLET_MNEMONIC: ${{ secrets.VITE_E2E_WALLET_MNEMONIC }}
       VITE_E2E_WALLET_ADDRESS: ${{ secrets.VITE_E2E_WALLET_ADDRESS }}
+      VITE_FEAT_UPDATED_DESIGN: true
     steps:
       - uses: actions/checkout@v4
 

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, retryButtonClick } from './fixtures';
 import { Chat } from './Chat';
 import { MetaMask } from './Metamask';
 import { ethers } from 'ethers';
+import { devices } from '@playwright/test';
 
 describe('chat', () => {
   test('renders intro message', async ({ page }) => {
@@ -202,5 +203,30 @@ describe('chat', () => {
     await chat.submitMessage('test message');
 
     await expect(modelButton).toBeDisabled();
+  });
+  test('model dropdown interactions in mobile', async ({ browser }) => {
+    const context = await browser.newContext({
+      ...devices['iPhone 13'],
+    });
+
+    const page = await context.newPage();
+
+    const chat = new Chat(page);
+    await chat.goto();
+
+    const modelButton = page.getByRole('button', { name: 'Select model' });
+    await modelButton.click();
+
+    const gpt4o = page.getByRole('option').filter({ hasText: /^gpt-4o$/ });
+    const gpt4oMini = page
+      .getByRole('option')
+      .filter({ hasText: /^gpt-4o-mini$/ });
+    const deepseek = page.getByRole('option').filter({ hasText: 'deepseek' });
+
+    await expect(gpt4o).toBeDisabled();
+    await expect(gpt4oMini).toBeDisabled();
+    await expect(deepseek).toBeEnabled();
+
+    await context.close();
   });
 });

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -3,6 +3,12 @@ import { Chat } from './Chat';
 import { MetaMask } from './Metamask';
 import { ethers } from 'ethers';
 import { devices } from '@playwright/test';
+import {
+  DEFAULT_MODEL_NAME,
+  NUMBER_OF_SUPPORTED_MODELS,
+} from '../src/core/config/models';
+import { blockchainModels } from '../src/features/blockchain/config/models';
+import { reasoningModels } from '../src/features/reasoning/config/models';
 
 describe('chat', () => {
   test('renders intro message', async ({ page }) => {
@@ -166,9 +172,6 @@ describe('chat', () => {
     expect(formattedAmount).toBe(0.2345);
   });
   test('model dropdown interactions', async ({ page }) => {
-    const NUMBER_OF_SUPPORTED_MODELS = 3;
-    const DEFAULT_MODEL_NAME = 'gpt-4o-mini';
-
     const chat = new Chat(page);
     await chat.goto();
 

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -3,10 +3,6 @@ import { Chat } from './Chat';
 import { MetaMask } from './Metamask';
 import { ethers } from 'ethers';
 import { devices } from '@playwright/test';
-import {
-  DEFAULT_MODEL_NAME,
-  NUMBER_OF_SUPPORTED_MODELS,
-} from '../src/core/config/models';
 
 describe('chat', () => {
   test('renders intro message', async ({ page }) => {
@@ -170,6 +166,8 @@ describe('chat', () => {
     expect(formattedAmount).toBe(0.2345);
   });
   test('model dropdown interactions', async ({ page }) => {
+    const DEFAULT_MODEL_NAME = 'gpt-4o-mini';
+    const NUMBER_OF_SUPPORTED_MODELS = 3;
     const chat = new Chat(page);
     await chat.goto();
 

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -7,8 +7,6 @@ import {
   DEFAULT_MODEL_NAME,
   NUMBER_OF_SUPPORTED_MODELS,
 } from '../src/core/config/models';
-import { blockchainModels } from '../src/features/blockchain/config/models';
-import { reasoningModels } from '../src/features/reasoning/config/models';
 
 describe('chat', () => {
   test('renders intro message', async ({ page }) => {
@@ -175,26 +173,25 @@ describe('chat', () => {
     const chat = new Chat(page);
     await chat.goto();
 
-    // Check default model
     const modelButton = page.getByRole('button', { name: 'Select model' });
     await expect(modelButton).toContainText(DEFAULT_MODEL_NAME);
 
     // Open dropdown and verify options
     await modelButton.click();
-    const dropdown = await page.getByTestId('model-dropdown-menu');
+    const dropdown = page.getByTestId('model-dropdown-menu');
     const dropdownOptions = await page.getByRole('option').all();
     await expect(dropdown).toBeVisible();
     expect(dropdownOptions).toHaveLength(NUMBER_OF_SUPPORTED_MODELS);
 
-    // // Select a different model
+    // Select a different model
     const alternativeModel = page.getByRole('option').first();
-    const newModelName = await alternativeModel.textContent();
-    expect(newModelName).not.toBe(DEFAULT_MODEL_NAME);
+    const alternativeModelName = await alternativeModel.textContent();
+    expect(alternativeModelName).not.toBe(DEFAULT_MODEL_NAME);
     await alternativeModel.click();
 
     // Verify dropdown closed and new model selected
     await expect(dropdown).not.toBeVisible();
-    await expect(modelButton).toContainText(newModelName);
+    await expect(modelButton).toContainText(alternativeModelName);
 
     // // Change back to original model
     await modelButton.click();

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -164,4 +164,43 @@ describe('chat', () => {
 
     expect(formattedAmount).toBe(0.2345);
   });
+  test('model dropdown interactions', async ({ page }) => {
+    const NUMBER_OF_SUPPORTED_MODELS = 3;
+    const DEFAULT_MODEL_NAME = 'gpt-4o-mini';
+
+    const chat = new Chat(page);
+    await chat.goto();
+
+    // Check default model
+    const modelButton = page.getByRole('button', { name: 'Select model' });
+    await expect(modelButton).toContainText(DEFAULT_MODEL_NAME);
+
+    // Open dropdown and verify options
+    await modelButton.click();
+    const dropdown = await page.getByTestId('model-dropdown-menu');
+    const dropdownOptions = await page.getByRole('option').all();
+    await expect(dropdown).toBeVisible();
+    expect(dropdownOptions).toHaveLength(NUMBER_OF_SUPPORTED_MODELS);
+
+    // // Select a different model
+    const alternativeModel = page.getByRole('option').first();
+    const newModelName = await alternativeModel.textContent();
+    expect(newModelName).not.toBe(DEFAULT_MODEL_NAME);
+    await alternativeModel.click();
+
+    // Verify dropdown closed and new model selected
+    await expect(dropdown).not.toBeVisible();
+    await expect(modelButton).toContainText(newModelName);
+
+    // // Change back to original model
+    await modelButton.click();
+    const originalModel = page.getByRole('option').nth(1);
+    await originalModel.click();
+    await expect(modelButton).toContainText(DEFAULT_MODEL_NAME);
+
+    // Type message to disable dropdown
+    await chat.submitMessage('test message');
+
+    await expect(modelButton).toBeDisabled();
+  });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -175,10 +175,7 @@ export const App = () => {
     <>
       {isReady && (
         <div className={styles.appContent}>
-          <NavBar
-            chatHistoryOpen={chatHistoryOpen}
-            setChatHistoryOpen={setChatHistoryOpen}
-          />
+          <NavBar setChatHistoryOpen={setChatHistoryOpen} />
           {showHistorySidebar ? (
             <div className={styles.appContainer}>
               {!isMobile ? (

--- a/src/core/components/ModelDropdownButton.tsx
+++ b/src/core/components/ModelDropdownButton.tsx
@@ -1,0 +1,70 @@
+import styles from './NavBar.module.css';
+import { useCallback, useEffect, useState } from 'react';
+import { useAppContext } from '../context/useAppContext';
+
+interface ModelDropdownButtonProps {
+  dropdownOpen: boolean;
+  setDropdownOpen: (dropdownOpen: boolean) => void;
+}
+
+const ModelDropdownButton = ({
+  dropdownOpen,
+  setDropdownOpen,
+}: ModelDropdownButtonProps) => {
+  const [isDisabled, setIsDisabled] = useState(false);
+
+  const { modelConfig, messageHistoryStore } = useAppContext();
+
+  const ModelIconComponent = modelConfig.icon;
+
+  const toggleDropdown = useCallback(() => {
+    if (!isDisabled) {
+      setDropdownOpen(!dropdownOpen);
+    }
+  }, [dropdownOpen, isDisabled, setDropdownOpen]);
+
+  // Handle message history changes
+  const messages = messageHistoryStore.getSnapshot();
+  const hasUserMessages = messages.length > 1;
+
+  useEffect(() => {
+    if (hasUserMessages) {
+      setIsDisabled(true);
+      setDropdownOpen(false);
+    } else {
+      setIsDisabled(false);
+    }
+  }, [hasUserMessages, setDropdownOpen]);
+
+  return (
+    <button
+      disabled={isDisabled}
+      className={styles.dropdown}
+      onClick={toggleDropdown}
+      aria-haspopup="true"
+      aria-expanded={dropdownOpen}
+      aria-label="Select model"
+    >
+      <ModelIconComponent />
+      <span>{modelConfig.name}</span>
+      <svg
+        width="16"
+        height="16"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        className={dropdownOpen ? styles.arrowUp : styles.arrowDown}
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M19 9l-7 7-7-7"
+        />
+      </svg>
+    </button>
+  );
+};
+
+export default ModelDropdownButton;

--- a/src/core/components/ModelDropdownExpanded.tsx
+++ b/src/core/components/ModelDropdownExpanded.tsx
@@ -2,32 +2,11 @@ import styles from './NavBar.module.css';
 import { getAllModels, isBlockchainModelName } from '../config/models';
 import { ModelConfig } from '../types/models';
 import { useAppContext } from '../context/useAppContext';
+import { useIsMobile } from '../../shared/theme/useIsMobile';
 
 interface ModelDropdownProps {
   setDropdownOpen: (dropdownOpen: boolean) => void;
 }
-
-import { useEffect, useState } from 'react';
-
-export const useMediaQuery = (query: string) => {
-  const [matches, setMatches] = useState<boolean>(
-    window.matchMedia(query).matches,
-  );
-
-  useEffect(() => {
-    const matchQuery = window.matchMedia(query);
-    const onChange = (e: MediaQueryListEvent) => {
-      setMatches(e.matches);
-    };
-
-    matchQuery.addEventListener('change', onChange);
-    return () => matchQuery.removeEventListener('change', onChange);
-  }, [query]);
-
-  return matches;
-};
-
-export const useIsMobile = () => useMediaQuery('(max-width: 768px)');
 
 const ModelDropdownExpanded = ({ setDropdownOpen }: ModelDropdownProps) => {
   const { handleModelChange } = useAppContext();

--- a/src/core/components/ModelDropdownExpanded.tsx
+++ b/src/core/components/ModelDropdownExpanded.tsx
@@ -1,0 +1,38 @@
+import styles from './NavBar.module.css';
+import { getAllModels } from '../config/models';
+import { ModelConfig } from '../types/models';
+import { useAppContext } from '../context/useAppContext';
+
+interface ModelDropdownProps {
+  setDropdownOpen: (dropdownOpen: boolean) => void;
+}
+
+const ModelDropdownExpanded = ({ setDropdownOpen }: ModelDropdownProps) => {
+  const { handleModelChange } = useAppContext();
+
+  const handleModelClick = (model: ModelConfig) => {
+    handleModelChange(model.id);
+    setDropdownOpen(false);
+  };
+  return (
+    <div className={styles.dropdownMenu} data-testid="model-dropdown-menu">
+      {getAllModels().map((model) => {
+        const ModelOptionIcon = model.icon;
+
+        return (
+          <button
+            key={model.name}
+            className={styles.dropdownItem}
+            onClick={() => handleModelClick(model)}
+            role="option"
+          >
+            <ModelOptionIcon />
+            <span>{model.name}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ModelDropdownExpanded;

--- a/src/core/components/ModelDropdownExpanded.tsx
+++ b/src/core/components/ModelDropdownExpanded.tsx
@@ -7,8 +7,32 @@ interface ModelDropdownProps {
   setDropdownOpen: (dropdownOpen: boolean) => void;
 }
 
+import { useEffect, useState } from 'react';
+
+export const useMediaQuery = (query: string) => {
+  const [matches, setMatches] = useState<boolean>(
+    window.matchMedia(query).matches,
+  );
+
+  useEffect(() => {
+    const matchQuery = window.matchMedia(query);
+    const onChange = (e: MediaQueryListEvent) => {
+      setMatches(e.matches);
+    };
+
+    matchQuery.addEventListener('change', onChange);
+    return () => matchQuery.removeEventListener('change', onChange);
+  }, [query]);
+
+  return matches;
+};
+
+export const useIsMobile = () => useMediaQuery('(max-width: 768px)');
+
 const ModelDropdownExpanded = ({ setDropdownOpen }: ModelDropdownProps) => {
   const { handleModelChange } = useAppContext();
+
+  const isMobile = useIsMobile();
 
   const handleModelClick = (model: ModelConfig) => {
     handleModelChange(model.id);
@@ -19,12 +43,15 @@ const ModelDropdownExpanded = ({ setDropdownOpen }: ModelDropdownProps) => {
       {getAllModels().map((model) => {
         const ModelOptionIcon = model.icon;
 
+        const disableOption = isMobile && model.id !== 'deepseek-chat';
+
         return (
           <button
             key={model.name}
             className={styles.dropdownItem}
             onClick={() => handleModelClick(model)}
             role="option"
+            disabled={disableOption}
           >
             <ModelOptionIcon />
             <span>{model.name}</span>

--- a/src/core/components/ModelDropdownExpanded.tsx
+++ b/src/core/components/ModelDropdownExpanded.tsx
@@ -17,27 +17,30 @@ const ModelDropdownExpanded = ({ setDropdownOpen }: ModelDropdownProps) => {
     handleModelChange(model.id);
     setDropdownOpen(false);
   };
+
+  const displayedModelOptions = getAllModels().map((model) => {
+    const ModelOptionIcon = model.icon;
+
+    //  since we don't support metamask on mobile, don't allow a user to switch to blockchain models
+    const disableOption = isMobile && isBlockchainModelName(model.id);
+
+    return (
+      <button
+        key={model.name}
+        className={styles.dropdownItem}
+        onClick={() => handleModelClick(model)}
+        role="option"
+        disabled={disableOption}
+      >
+        <ModelOptionIcon />
+        <span>{model.name}</span>
+      </button>
+    );
+  });
+
   return (
     <div className={styles.dropdownMenu} data-testid="model-dropdown-menu">
-      {getAllModels().map((model) => {
-        const ModelOptionIcon = model.icon;
-
-        //  since we don't support metamask on mobile, don't allow a user to switch to blockchain models
-        const disableOption = isMobile && isBlockchainModelName(model.id);
-
-        return (
-          <button
-            key={model.name}
-            className={styles.dropdownItem}
-            onClick={() => handleModelClick(model)}
-            role="option"
-            disabled={disableOption}
-          >
-            <ModelOptionIcon />
-            <span>{model.name}</span>
-          </button>
-        );
-      })}
+      {displayedModelOptions}
     </div>
   );
 };

--- a/src/core/components/ModelDropdownExpanded.tsx
+++ b/src/core/components/ModelDropdownExpanded.tsx
@@ -1,5 +1,5 @@
 import styles from './NavBar.module.css';
-import { getAllModels } from '../config/models';
+import { getAllModels, isBlockchainModelName } from '../config/models';
 import { ModelConfig } from '../types/models';
 import { useAppContext } from '../context/useAppContext';
 
@@ -43,7 +43,8 @@ const ModelDropdownExpanded = ({ setDropdownOpen }: ModelDropdownProps) => {
       {getAllModels().map((model) => {
         const ModelOptionIcon = model.icon;
 
-        const disableOption = isMobile && model.id !== 'deepseek-chat';
+        //  since we don't support metamask on mobile, don't allow a user to switch to blockchain models
+        const disableOption = isMobile && isBlockchainModelName(model.id);
 
         return (
           <button

--- a/src/core/components/ModelSelector.tsx
+++ b/src/core/components/ModelSelector.tsx
@@ -1,0 +1,38 @@
+import ModelDropdownButton from './ModelDropdownButton';
+import ModelDropdownExpanded from './ModelDropdownExpanded';
+import { useEffect, useState } from 'react';
+import styles from './NavBar.module.css';
+
+const ModelSelector = () => {
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  // Handle closing dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const dropdown = document.querySelector(`.${styles.dropdownContainer}`);
+      if (dropdown && !dropdown.contains(event.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+
+    if (dropdownOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () =>
+        document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [dropdownOpen]);
+
+  return (
+    <>
+      <ModelDropdownButton
+        dropdownOpen={dropdownOpen}
+        setDropdownOpen={setDropdownOpen}
+      />
+      {dropdownOpen && (
+        <ModelDropdownExpanded setDropdownOpen={setDropdownOpen} />
+      )}
+    </>
+  );
+};
+
+export default ModelSelector;

--- a/src/core/components/NavBar.module.css
+++ b/src/core/components/NavBar.module.css
@@ -1,26 +1,26 @@
 .container {
   display: flex;
   flex-direction: column;
-  background-color: #111111;
+  background-color: var(--colors-bgPrimary);
 }
 
 .nav {
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  background-color: #111111;
-  border-bottom: 2px solid #222222;
+  background-color: var(--colors-bgPrimary);
+  border-bottom: 2px solid var(--colors-bgSecondary);
 }
 
 .menu {
   display: flex;
   align-items: center;
   width: 100%;
-  border-bottom: 2px solid #222222;
+  border-bottom: 2px solid var(--colors-bgSecondary);
 }
 
 .hamburger {
-  padding: 16px;
+  padding: var(--spacing-md);
   display: flex;
   align-items: center;
 }
@@ -28,7 +28,7 @@
 .logo {
   display: flex;
   align-items: center;
-  padding: 16px;
+  padding: var(--spacing-md);
   width: 100%;
   justify-content: center;
 }
@@ -43,11 +43,11 @@
 .dropdown {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 8px 16px;
-  background-color: #111111;
-  border-radius: 8px;
-  color: #ffffff;
+  gap: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--colors-bgPrimary);
+  border-radius: var(--borderRadius-sm);
+  color: var(--colors-textPrimary);
   cursor: pointer;
   border: none;
   height: 62px;
@@ -63,23 +63,23 @@
   top: 100%;
   left: 50%;
   transform: translateX(-50%);
-  background-color: #222222;
-  border-radius: 8px;
-  border: 1px solid #444444;
+  background-color: var(--colors-bgSecondary);
+  border-radius: var(--borderRadius-sm);
+  border: 1px solid var(--colors-bgTertiary);
   display: flex;
   flex-direction: column;
-  width: 220px; /* Match button width */
-  margin-top: 4px;
+  width: 220px;
+  margin-top: var(--spacing-xs);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
 .dropdownItem {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 10px 16px;
-  background-color: #222222;
-  color: #ffffff;
+  gap: var(--spacing-md);
+  padding: 10px var(--spacing-md);
+  background-color: var(--colors-bgSecondary);
+  color: var(--colors-textPrimary);
   border: none;
   cursor: pointer;
   width: 100%;
@@ -87,35 +87,26 @@
 }
 
 .dropdownItem:hover {
-  background-color: #333333;
+  background-color: var(--colors-bgTertiary);
 }
 
 .dropdownItem:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-  background-color: #1a1a1a;
+  background-color: var(--colors-bgPrimary);
 }
 
 .dropdownItem:disabled:hover {
-  background-color: #1a1a1a;
-}
-.arrowDown {
-  transform: rotate(0deg);
-  transition: transform 0.2s ease-in-out;
-}
-
-.arrowUp {
-  transform: rotate(180deg);
-  transition: transform 0.2s ease-in-out;
+  background-color: var(--colors-bgPrimary);
 }
 
 @media (min-width: 768px) {
   .nav {
     flex-direction: row;
     justify-content: space-between;
-    padding: 8px 16px;
+    padding: var(--spacing-sm) var(--spacing-md);
     height: 89px;
-    border-bottom: 2px solid #222222;
+    border-bottom: 2px solid var(--colors-bgSecondary);
   }
 
   .menu {
@@ -134,8 +125,8 @@
   }
 
   .dropdown {
-    width: 220px; /* Ensure fixed width remains */
-    border: 1px solid #a3a3a3;
+    width: 220px;
+    border: 1px solid var(--colors-textMuted);
   }
 
   .dropdownMenu {

--- a/src/core/components/NavBar.module.css
+++ b/src/core/components/NavBar.module.css
@@ -100,6 +100,16 @@
   background-color: var(--colors-bgPrimary);
 }
 
+.arrowDown {
+  transform: rotate(0deg);
+  transition: transform 0.2s ease-in-out;
+}
+
+.arrowUp {
+  transform: rotate(180deg);
+  transition: transform 0.2s ease-in-out;
+}
+
 @media (min-width: 768px) {
   .nav {
     flex-direction: row;

--- a/src/core/components/NavBar.module.css
+++ b/src/core/components/NavBar.module.css
@@ -90,6 +90,15 @@
   background-color: #333333;
 }
 
+.dropdownItem:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background-color: #1a1a1a;
+}
+
+.dropdownItem:disabled:hover {
+  background-color: #1a1a1a;
+}
 .arrowDown {
   transform: rotate(0deg);
   transition: transform 0.2s ease-in-out;

--- a/src/core/components/NavBar.tsx
+++ b/src/core/components/NavBar.tsx
@@ -21,7 +21,6 @@ const NavBar = ({ setChatHistoryOpen }: NavBarProps) => {
     useAppContext();
 
   const ModelIconComponent = modelConfig.icon;
-
   const [isDisabled, setIsDisabled] = useState(false);
 
   // Handle closing dropdown when clicking outside
@@ -52,48 +51,6 @@ const NavBar = ({ setChatHistoryOpen }: NavBarProps) => {
       setIsDisabled(false);
     }
   }, [hasUserMessages]);
-
-  // Keyboard navigation
-  // useEffect(() => {
-  //   const handleKeyDown = (e: KeyboardEvent) => {
-  //     if (!dropdownOpen) return;
-  //
-  //     switch (e.key) {
-  //       case 'Escape':
-  //         setDropdownOpen(false);
-  //         break;
-  //       case 'ArrowDown': {
-  //         e.preventDefault();
-  //         const currentIndex = modelOptions.findIndex(
-  //           (m) => m.id === selectedModel.id,
-  //         );
-  //         const nextIndex = (currentIndex + 1) % modelOptions.length;
-  //         setSelectedModel(modelOptions[nextIndex]);
-  //         break;
-  //       }
-  //       case 'ArrowUp': {
-  //         e.preventDefault();
-  //         const currIndex = modelOptions.findIndex(
-  //           (m) => m.id === selectedModel.id,
-  //         );
-  //         const prevIndex =
-  //           currIndex === 0 ? modelOptions.length - 1 : currIndex - 1;
-  //         setSelectedModel(modelOptions[prevIndex]);
-  //         break;
-  //       }
-  //     }
-  //   };
-  //
-  //   if (dropdownOpen) {
-  //     window.addEventListener('keydown', handleKeyDown);
-  //     return () => window.removeEventListener('keydown', handleKeyDown);
-  //   }
-  // }, [dropdownOpen, selectedModel]);
-  //
-  // const handleSelect = useCallback((model: ModelOption) => {
-  //   setSelectedModel(model);
-  //   setDropdownOpen(false);
-  // }, []);
 
   const toggleDropdown = useCallback(() => {
     if (!isDisabled) {
@@ -164,6 +121,7 @@ const NavBar = ({ setChatHistoryOpen }: NavBarProps) => {
                     key={model.name}
                     className={styles.dropdownItem}
                     onClick={() => handleModelClick(model)}
+                    role="option"
                   >
                     <ModelOptionIcon />
                     <span>{model.name}</span>

--- a/src/core/components/NavBar.tsx
+++ b/src/core/components/NavBar.tsx
@@ -1,11 +1,8 @@
-import { useEffect, useState, useCallback } from 'react';
 import styles from './NavBar.module.css';
 import KavaAILogo from '../assets/KavaAILogo';
 import HamburgerIcon from '../assets/HamburgerIcon';
 import { isInIframe } from '../utils/isInIframe';
-import { useAppContext } from '../context/useAppContext';
-import { getAllModels } from '../config/models';
-import { ModelConfig } from '../types/models';
+import ModelSelector from './ModelSelector';
 
 const FEAT_UPDATED_DESIGN = import.meta.env.VITE_FEAT_UPDATED_DESIGN;
 
@@ -14,54 +11,7 @@ interface NavBarProps {
 }
 
 const NavBar = ({ setChatHistoryOpen }: NavBarProps) => {
-  const isIframe = isInIframe();
-  const showNavBar = !isIframe && FEAT_UPDATED_DESIGN;
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-  const { modelConfig, handleModelChange, messageHistoryStore } =
-    useAppContext();
-
-  const ModelIconComponent = modelConfig.icon;
-  const [isDisabled, setIsDisabled] = useState(false);
-
-  // Handle closing dropdown when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      const dropdown = document.querySelector(`.${styles.dropdownContainer}`);
-      if (dropdown && !dropdown.contains(event.target as Node)) {
-        setDropdownOpen(false);
-      }
-    };
-
-    if (dropdownOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-      return () =>
-        document.removeEventListener('mousedown', handleClickOutside);
-    }
-  }, [dropdownOpen]);
-
-  // Handle message history changes
-  const messages = messageHistoryStore.getSnapshot();
-  const hasUserMessages = messages.length > 1;
-
-  useEffect(() => {
-    if (hasUserMessages) {
-      setIsDisabled(true);
-      setDropdownOpen(false);
-    } else {
-      setIsDisabled(false);
-    }
-  }, [hasUserMessages]);
-
-  const toggleDropdown = useCallback(() => {
-    if (!isDisabled) {
-      setDropdownOpen((prev) => !prev);
-    }
-  }, [isDisabled]);
-
-  const handleModelClick = (model: ModelConfig) => {
-    handleModelChange(model.id);
-    setDropdownOpen(false);
-  };
+  const showNavBar = !isInIframe() && FEAT_UPDATED_DESIGN;
 
   if (!showNavBar) return null;
 
@@ -81,58 +31,8 @@ const NavBar = ({ setChatHistoryOpen }: NavBarProps) => {
             <KavaAILogo />
           </div>
         </div>
-
         <div className={styles.dropdownContainer}>
-          <button
-            disabled={isDisabled}
-            className={styles.dropdown}
-            onClick={toggleDropdown}
-            aria-haspopup="true"
-            aria-expanded={dropdownOpen}
-            aria-label="Select model"
-          >
-            <ModelIconComponent />
-            <span>{modelConfig.name}</span>
-            <svg
-              width="16"
-              height="16"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              className={dropdownOpen ? styles.arrowUp : styles.arrowDown}
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M19 9l-7 7-7-7"
-              />
-            </svg>
-          </button>
-
-          {dropdownOpen && (
-            <div
-              className={styles.dropdownMenu}
-              data-testid="model-dropdown-menu"
-            >
-              {getAllModels().map((model) => {
-                const ModelOptionIcon = model.icon;
-
-                return (
-                  <button
-                    key={model.name}
-                    className={styles.dropdownItem}
-                    onClick={() => handleModelClick(model)}
-                    role="option"
-                  >
-                    <ModelOptionIcon />
-                    <span>{model.name}</span>
-                  </button>
-                );
-              })}
-            </div>
-          )}
+          <ModelSelector />
         </div>
       </nav>
     </div>

--- a/src/core/components/NavBar.tsx
+++ b/src/core/components/NavBar.tsx
@@ -112,7 +112,10 @@ const NavBar = ({ setChatHistoryOpen }: NavBarProps) => {
           </button>
 
           {dropdownOpen && (
-            <div className={styles.dropdownMenu}>
+            <div
+              className={styles.dropdownMenu}
+              data-testid="model-dropdown-menu"
+            >
               {getAllModels().map((model) => {
                 const ModelOptionIcon = model.icon;
 

--- a/src/core/config/models.ts
+++ b/src/core/config/models.ts
@@ -39,3 +39,10 @@ export const getAllModels = (): ModelConfig[] => {
     ...Object.values(MODEL_REGISTRY.reasoning),
   ];
 };
+
+export const DEFAULT_MODEL_NAME = 'gpt-4o-mini';
+
+export const NUMBER_OF_SUPPORTED_MODELS = Object.values(MODEL_REGISTRY).reduce(
+  (total, models) => total + Object.keys(models).length,
+  0,
+);

--- a/src/core/config/models.ts
+++ b/src/core/config/models.ts
@@ -10,7 +10,7 @@ export const MODEL_REGISTRY: ModelRegistry = {
   reasoning: reasoningModels,
 };
 
-const isBlockchainModelName = (
+export const isBlockchainModelName = (
   name: SupportedModels,
 ): name is SupportedBlockchainModels => {
   return Object.keys(MODEL_REGISTRY.blockchain).includes(name);

--- a/src/core/config/models.ts
+++ b/src/core/config/models.ts
@@ -41,8 +41,3 @@ export const getAllModels = (): ModelConfig[] => {
 };
 
 export const DEFAULT_MODEL_NAME = 'gpt-4o-mini';
-
-export const NUMBER_OF_SUPPORTED_MODELS = Object.values(MODEL_REGISTRY).reduce(
-  (total, models) => total + Object.keys(models).length,
-  0,
-);

--- a/src/core/context/AppContextProvider.tsx
+++ b/src/core/context/AppContextProvider.tsx
@@ -7,7 +7,7 @@ import { ToolCallStreamStore } from '../../core/stores/toolCallStreamStore';
 import { MessageHistoryStore } from '../../core/stores/messageHistoryStore';
 import { initializeMessageRegistry } from '../../features/blockchain/config/initializeMessageRegistry';
 import { useExecuteOperation } from './useExecuteOperation';
-import { getModelConfig } from '../config/models';
+import { DEFAULT_MODEL_NAME, getModelConfig } from '../config/models';
 import { SupportedModels, ModelConfig } from '../types/models';
 
 export const AppContextProvider = ({
@@ -33,7 +33,7 @@ export const AppContextProvider = ({
   );
 
   const [modelConfig, setModelConfig] = useState<ModelConfig>(() =>
-    getModelConfig('gpt-4o-mini'),
+    getModelConfig(DEFAULT_MODEL_NAME),
   );
 
   // This callback would be passed to components that need to switch models

--- a/src/features/blockchain/components/displayCards/DisplayCards.module.css
+++ b/src/features/blockchain/components/displayCards/DisplayCards.module.css
@@ -9,7 +9,6 @@
   padding-bottom: 10px;
 }
 
-
 .inprogressContainer {
   width: 100%;
   max-width: 600px;


### PR DESCRIPTION

## Summary
- if a user clicks outside of the dropdown it closes
- a user can use the arrow keys to toggle options
- the user can use the enter and escape keys to manipulate the dropdown
- the dropdown is disabled if a user has started a chat, but becomes enabled again when history is cleared

## Demo 


https://github.com/user-attachments/assets/526a6c31-5b19-48ac-ad3a-94404f6d55da


## Todo
- [x] testing
- [x] componentization/refactor
- [ ] move key handling/outside click to hooks
