### PR TITLE
poc: use LLM to generate summary of chat

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import NavBar from './core/components/NavBar';
 import styles from './App.module.css';
 import { ChatHistory } from './core/components/ChatHistory';
 import { ModelConfig } from './core/types/models';
+import { useSummarizeChat } from './core/utils/useSummarizeChat';
 
 let client: OpenAI | null = null;
 
@@ -153,6 +154,10 @@ export const App = () => {
       { role: 'system' as const, content: modelConfig.systemPrompt },
     ]);
   }, [handleCancel, messageHistoryStore, modelConfig.systemPrompt]);
+
+  const summary = useSummarizeChat(client as OpenAI, messages);
+
+  console.log('summary', summary);
 
   return (
     <>

--- a/src/core/utils/useSummarizeChat.ts
+++ b/src/core/utils/useSummarizeChat.ts
@@ -1,0 +1,44 @@
+import { useState, useEffect } from 'react';
+import OpenAI from 'openai';
+import { ChatCompletionMessageParam } from 'openai/resources/index';
+
+export const useSummarizeChat = (
+  client: OpenAI,
+  messages: ChatCompletionMessageParam[],
+): string => {
+  const [summary, setSummary] = useState('');
+
+  useEffect(() => {
+    if (!messages?.length) return;
+
+    const generateSummary = async () => {
+      const initialMessages = messages.slice(0, 3);
+
+      try {
+        const completion = await client.chat.completions.create({
+          model: 'gpt-4o-mini',
+          messages: [
+            {
+              role: 'system',
+              content:
+                'Generate a brief, descriptive title (max 60 chars) for this chat based on the first user message.',
+            },
+            ...initialMessages,
+          ],
+        });
+
+        setSummary(completion.choices[0].message.content as string);
+      } catch (error) {
+        console.error('Error generating summary:', error);
+        const firstMessage = initialMessages.find(
+          (m) => m.role === 'user',
+        )?.content;
+        setSummary(firstMessage?.slice(0, 57) + '...' || 'New Chat');
+      }
+    };
+
+    generateSummary();
+  }, [messages, client]);
+
+  return summary;
+};


### PR DESCRIPTION
## Summary

Not intended to be merged, but can be used as a basis for implementation when we want to go beyond just simply putting the first however many characters of the user's first message. 

## Demo

User: "Can you help me send KAVA to another address?"
Summary: ""Assistance with Kava Transactions and Balance Inquiries" 
