### PR TITLE
ci: Upload encrypted playwright test results to artifacts on failure

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -185,6 +185,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
+        id: playwright-tests
         run: DEBUG=pw:webserver xvfb-run npx playwright test
 
       - name: Output logs if containers are unhealthy or if tests fail
@@ -192,7 +193,7 @@ jobs:
         run: docker compose -f docker-compose.yaml logs
 
       - name: Zip and encrypt Playwright test results if tests failed
-        if: failure()
+        if: failure() && steps.playwright-tests.outputs.outcome == 'failure'
         run: |
           # Regular zip
           zip -r test-results.zip test-results
@@ -228,7 +229,7 @@ jobs:
           rm test-results.zip
 
       - name: Upload encrypted zip file to artifacts
-        if: failure()
+        if: failure() && steps.playwright-tests.outputs.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-test-results

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -226,7 +226,7 @@ jobs:
           echo "Encrypting test results with gpg key ID $KEY_ID"
 
           # Encrypt zip file with pubkey
-          gpg --output test-results.zip.gpg --encrypt --recipient $KEY_ID test-results.zip
+          gpg --output test-results.zip.gpg --encrypt --trust-model always --recipient $KEY_ID test-results.zip
 
           # Delete the unencrypted zip file so there's no chance of accidentally
           # uploading it

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -199,6 +199,7 @@ jobs:
 
           # Fetch GitHub username from pusher event
           USERNAME=$(echo ${{ github.event.pusher.username }})
+          echo "Pusher username: $USERNAME"
 
           # Exit if invalid username
           if [ -z "$USERNAME" ]; then
@@ -211,6 +212,7 @@ jobs:
 
           # Get key ID of the most recent pubkey
           KEY_ID=$(gpg --list-keys --with-colons | awk -F: '/^pub/ {print $5}' | tail -n 1)
+          echo "Encrypting test results with gpg key ID $KEY_ID"
 
           # Encrypt zip file with pubkey
           gpg --output test-results.zip.gpg --encrypt --recipient $KEY_ID test-results.zip

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -202,9 +202,15 @@ jobs:
           # Regular zip
           zip -r test-results.zip test-results
 
-          # Fetch GitHub username from pusher event
-          USERNAME=$(echo ${{ github.event.pusher.username }})
-          echo "Pusher username: $USERNAME"
+          # Fetch GitHub username from pull_request event
+          USERNAME=$(echo ${{ github.event.pull_request.user.login }})
+
+          # Fetch GitHub username from pusher event empty
+          if [ -z "$USERNAME" ]; then
+            USERNAME=$(echo ${{ github.event.pusher.username }})
+          fi
+
+          echo "GitHub Username: $USERNAME"
 
           # Exit if invalid username
           if [ -z "$USERNAME" ]; then

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -185,7 +185,12 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        run: DEBUG=pw:webserver xvfb-run npx playwright test
+        run: |
+          DEBUG=pw:webserver xvfb-run npx playwright test
+
+          # Purposefully trigger a failure to test the failure steps
+          echo "Failing the build"
+          exit 1
 
       - name: Output logs if containers are unhealthy or if tests fail
         if: failure()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -185,12 +185,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        run: |
-          DEBUG=pw:webserver xvfb-run npx playwright test
-
-          # Purposefully trigger a failure to test the failure steps
-          echo "Failing the build"
-          exit 1
+        run: DEBUG=pw:webserver xvfb-run npx playwright test
 
       - name: Output logs if containers are unhealthy or if tests fail
         if: failure()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -191,6 +191,41 @@ jobs:
         if: failure()
         run: docker compose -f docker-compose.yaml logs
 
+      - name: Zip and encrypt Playwright test results if tests failed
+        if: failure()
+        run: |
+          # Regular zip
+          zip -r test-results.zip test-results
+
+          # Fetch GitHub username from pusher event
+          USERNAME=$(echo ${{ github.event.pusher.username }})
+
+          # Exit if invalid username
+          if [ -z "$USERNAME" ]; then
+            echo "No GitHub username found, exiting"
+            exit 1
+          fi
+
+          # Fetch GPG pubkey from github.com/<username>.gpg
+          curl -sSL https://github.com/$USERNAME.gpg | gpg --import
+
+          # Get key ID of the most recent pubkey
+          KEY_ID=$(gpg --list-keys --with-colons | awk -F: '/^pub/ {print $5}' | tail -n 1)
+
+          # Encrypt zip file with pubkey
+          gpg --output test-results.zip.gpg --encrypt --recipient $KEY_ID test-results.zip
+
+          # Delete the unencrypted zip file so there's no chance of accidentally
+          # uploading it
+          rm test-results.zip
+
+      - name: Upload encrypted zip file to artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: test-results.zip.gpg
+
       - name: Shutdown proxy and kava node
         if: always()
         run: docker compose -f docker-compose.yaml down


### PR DESCRIPTION
## Summary
If playwright tests fail, encrypts playwright test results with the pull request / pusher's gpg key set in github
