### PR TITLE
feat: conversation history search function

### DIFF
--- a/src/core/utils/searchConversationHistory.test.ts
+++ b/src/core/utils/searchConversationHistory.test.ts
@@ -1,0 +1,56 @@
+import { searchConversationHistory } from './searchConversationHistory';
+import { ConversationHistory } from '../context/types';
+
+describe('searchConversationHistory', () => {
+  const mockConversations: Record<string, ConversationHistory> = {
+    '1': {
+      id: '1',
+      model: 'test-model',
+      title: '"Greeting discussion"', //  extra quotations added by model
+      conversation: [],
+      lastSaved: 123456789,
+    },
+    '2': {
+      id: '2',
+      model: 'test-model',
+      title: 'Project Planning',
+      conversation: [],
+      lastSaved: 123456789,
+    },
+    '3': {
+      id: '3',
+      model: 'test-model',
+      title: 'Great Ideas',
+      conversation: [],
+      lastSaved: 123456789,
+    },
+  };
+
+  it('should return empty array for empty search term', () => {
+    const result = searchConversationHistory('', mockConversations);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array for empty conversations', () => {
+    const result = searchConversationHistory('test', {});
+    expect(result).toEqual([]);
+  });
+
+  it('should find matches (case-insensitive)', () => {
+    const result = searchConversationHistory('gre', mockConversations);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({ id: '1', title: '"Greeting discussion"' });
+    expect(result).toContainEqual({ id: '3', title: 'Great Ideas' });
+  });
+
+  it('should return empty array for non-matching search', () => {
+    const result = searchConversationHistory('xyz', mockConversations);
+    expect(result).toEqual([]);
+  });
+
+  it('should match partial words', () => {
+    const result = searchConversationHistory('planning ', mockConversations);
+    expect(result).toHaveLength(1);
+    expect(result).toContainEqual({ id: '2', title: 'Project Planning' });
+  });
+});

--- a/src/core/utils/searchConversationHistory.ts
+++ b/src/core/utils/searchConversationHistory.ts
@@ -1,0 +1,33 @@
+import { ConversationHistory } from '../context/types';
+
+interface SearchResult {
+  id: string;
+  title: string;
+}
+
+/**
+ * Searches through conversation history for matches in titles
+ * @param searchTerm - The term to search for
+ * @param conversations - The conversation store object
+ * @returns Array of matching conversation IDs and titles
+ */
+export function searchConversationHistory(
+  searchTerm: string,
+  conversations: Record<string, ConversationHistory>,
+): SearchResult[] {
+  if (searchTerm.length === 0 || Object.keys(conversations).length === 0) {
+    return [];
+  }
+
+  const term = searchTerm.toLowerCase().trim();
+
+  return Object.entries(conversations)
+    .filter(([_, data]) => {
+      const title = data.title.toLowerCase();
+      return title.includes(term);
+    })
+    .map(([id, data]) => ({
+      id,
+      title: data.title,
+    }));
+}


### PR DESCRIPTION
## Summary
- creates a unit-tested, currently unimplemented helper that takes in the the object from local storage conversation history 
and returns an array of the matching conversation's id & title (might only need id?)