### PR TITLE
feat: add tooltip for disabled states in model selection

### DIFF
--- a/src/core/components/ModelDropdownButton.tsx
+++ b/src/core/components/ModelDropdownButton.tsx
@@ -1,6 +1,8 @@
-import styles from './NavBar.module.css';
 import { useCallback, useEffect, useState } from 'react';
 import { useAppContext } from '../context/useAppContext';
+import styles from './NavBar.module.css';
+import Tooltip from './ToolTip';
+import { useIsMobile } from '../../shared/theme/useIsMobile';
 
 interface ModelDropdownButtonProps {
   dropdownOpen: boolean;
@@ -11,10 +13,9 @@ const ModelDropdownButton = ({
   dropdownOpen,
   setDropdownOpen,
 }: ModelDropdownButtonProps) => {
+  const isMobile = useIsMobile();
   const [isDisabled, setIsDisabled] = useState(false);
-
   const { modelConfig, messageHistoryStore } = useAppContext();
-
   const ModelIconComponent = modelConfig.icon;
 
   const toggleDropdown = useCallback(() => {
@@ -23,7 +24,6 @@ const ModelDropdownButton = ({
     }
   }, [dropdownOpen, isDisabled, setDropdownOpen]);
 
-  // Handle message history changes
   const messages = messageHistoryStore.getSnapshot();
   const hasUserMessages = messages.length > 1;
 
@@ -36,7 +36,7 @@ const ModelDropdownButton = ({
     }
   }, [hasUserMessages, setDropdownOpen]);
 
-  return (
+  const button = (
     <button
       disabled={isDisabled}
       className={styles.dropdown}
@@ -74,6 +74,17 @@ const ModelDropdownButton = ({
         />
       </svg>
     </button>
+  );
+
+  return isDisabled ? (
+    <Tooltip
+      content="Model switching is disabled once a chat has started"
+      topMargin={isMobile ? '100' : '65'}
+    >
+      {button}
+    </Tooltip>
+  ) : (
+    button
   );
 };
 

--- a/src/core/components/ModelDropdownButton.tsx
+++ b/src/core/components/ModelDropdownButton.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useAppContext } from '../context/useAppContext';
 import styles from './NavBar.module.css';
-import Tooltip from './ToolTip';
+import Tooltip from './Tooltip';
 import { useIsMobile } from '../../shared/theme/useIsMobile';
 
 interface ModelDropdownButtonProps {

--- a/src/core/components/ModelDropdownExpanded.tsx
+++ b/src/core/components/ModelDropdownExpanded.tsx
@@ -3,6 +3,7 @@ import { getAllModels, isBlockchainModelName } from '../config/models';
 import { ModelConfig } from '../types/models';
 import { useAppContext } from '../context/useAppContext';
 import { useIsMobile } from '../../shared/theme/useIsMobile';
+import Tooltip from './Tooltip';
 
 interface ModelDropdownProps {
   setDropdownOpen: (dropdownOpen: boolean) => void;
@@ -10,7 +11,6 @@ interface ModelDropdownProps {
 
 const ModelDropdownExpanded = ({ setDropdownOpen }: ModelDropdownProps) => {
   const { handleModelChange } = useAppContext();
-
   const isMobile = useIsMobile();
 
   const handleModelClick = (model: ModelConfig) => {
@@ -20,11 +20,9 @@ const ModelDropdownExpanded = ({ setDropdownOpen }: ModelDropdownProps) => {
 
   const displayedModelOptions = getAllModels().map((model) => {
     const ModelOptionIcon = model.icon;
-
-    //  since we don't support metamask on mobile, don't allow a user to switch to blockchain models
     const disableOption = isMobile && isBlockchainModelName(model.id);
 
-    return (
+    const modelButton = (
       <button
         key={model.name}
         className={styles.dropdownItem}
@@ -35,6 +33,18 @@ const ModelDropdownExpanded = ({ setDropdownOpen }: ModelDropdownProps) => {
         <ModelOptionIcon />
         <span>{model.name}</span>
       </button>
+    );
+
+    return disableOption ? (
+      <Tooltip
+        key={model.name}
+        content="Blockchain models are not supported on mobile devices"
+        topMargin="30"
+      >
+        {modelButton}
+      </Tooltip>
+    ) : (
+      modelButton
     );
   });
 

--- a/src/core/components/NavBar.module.css
+++ b/src/core/components/NavBar.module.css
@@ -65,7 +65,6 @@
 
 .dropdown:disabled {
   opacity: 0.6;
-  cursor: not-allowed;
   background-color: var(--colors-bgTertiary);
 }
 
@@ -103,7 +102,6 @@
 
 .dropdownItem:disabled {
   opacity: 0.5;
-  cursor: not-allowed;
   background-color: var(--colors-bgPrimary);
 }
 

--- a/src/core/components/Tooltip.module.css
+++ b/src/core/components/Tooltip.module.css
@@ -1,0 +1,15 @@
+.container {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip {
+  position: fixed;
+  z-index: 50;
+  padding: 8px 12px;
+  font-size: 14px;
+  color: white;
+  background-color: var(--colors-bgTertiary);
+  border-radius: var(--borderRadius-sm);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}

--- a/src/core/components/Tooltip.tsx
+++ b/src/core/components/Tooltip.tsx
@@ -1,0 +1,44 @@
+import React, { useState, useRef, useEffect } from 'react';
+import styles from './Tooltip.module.css';
+
+interface TooltipProps {
+  content: string;
+  children: React.ReactNode;
+  topMargin: string;
+}
+
+const Tooltip = ({ content, children, topMargin }: TooltipProps) => {
+  const [show, setShow] = useState(false);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const targetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (show && tooltipRef.current && targetRef.current) {
+      const targetRect = targetRef.current.getBoundingClientRect();
+      const tooltipRect = tooltipRef.current.getBoundingClientRect();
+
+      const left = targetRect.left + (targetRect.width - tooltipRect.width) / 2;
+
+      tooltipRef.current.style.top = `${topMargin}px`;
+      tooltipRef.current.style.left = `${left}px`;
+    }
+  }, [show, topMargin]);
+
+  return (
+    <div
+      className={styles.container}
+      onMouseEnter={() => setShow(true)}
+      onMouseLeave={() => setShow(false)}
+      ref={targetRef}
+    >
+      {children}
+      {show && (
+        <div ref={tooltipRef} className={styles.tooltip} role="tooltip">
+          {content}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Tooltip;


### PR DESCRIPTION
## Summary
- creates a reusable, positionable tooltip component for handling the disabled state of the model selector dropdown (when a conversation has started) and for switching to a blockchain model on mobile

## Demo 


https://github.com/user-attachments/assets/1aafe8c7-7ae0-4321-98e0-793b0ef82acf


