### PR TITLE
fix: allow users to scroll up when content is streaming

### DIFF
--- a/src/core/components/ChatView.tsx
+++ b/src/core/components/ChatView.tsx
@@ -58,16 +58,6 @@ export const ChatView = ({
     containerRef.current.scrollTop = containerRef.current.scrollHeight;
   }, []);
 
-  const handleContentRendered = useCallback(() => {
-    if (!containerRef.current) return;
-
-    if (shouldAutoScroll) {
-      requestAnimationFrame(() => {
-        scrollToBottom();
-      });
-    }
-  }, [shouldAutoScroll, scrollToBottom]);
-
   // Reset textarea height when input is cleared
   useEffect(() => {
     if (inputRef.current && inputValue === '') {
@@ -88,11 +78,27 @@ export const ChatView = ({
   const hasMessages =
     messages.filter((message) => message.role != 'system').length > 0;
 
+  const handleContentRendered = useCallback(() => {
+    if (!containerRef.current) return;
+
+    if (shouldAutoScroll) {
+      requestAnimationFrame(() => {
+        scrollToBottom();
+      });
+    }
+  }, [shouldAutoScroll, scrollToBottom]);
+
   const handleInputChange = useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      /**
+       * Set the text area height to 'auto' on change so the height is
+       * automatically adjusted as the user types. Set it to the
+       * scrollHeight so as the user types, the textarea content moves
+       * upward keeping the user on the same line
+       */
       const textarea = event.target;
-      textarea.style.height = DEFAULT_HEIGHT;
-      textarea.style.height = `min(${textarea.scrollHeight}px, 60vh)`;
+      textarea.style.height = DEFAULT_HEIGHT; // Reset to default height first
+      textarea.style.height = `min(${textarea.scrollHeight}px, 60vh)`; // Adjust to scrollHeight
       setInputValue(textarea.value);
     },
     [],
@@ -117,6 +123,7 @@ export const ChatView = ({
     setInputValue('');
     setShouldAutoScroll(true); // Reset scroll state when sending new message
 
+    // Reset height after submitting
     if (inputRef.current) {
       inputRef.current.style.height = DEFAULT_HEIGHT;
     }


### PR DESCRIPTION
## Summary
Addresses #317 

Auto-scroll the chat as before, but if a user decides to scroll up, allow them to do so. 

If they scroll back to the bottom of the chat, resume auto-scroll

## Before
It only allowed me to scroll up briefly when the stream paused/slowed down

https://github.com/user-attachments/assets/2e9ba141-d53a-4d94-a615-040525edd99d



## After

https://github.com/user-attachments/assets/1e836fb6-77a6-404c-9fcf-9557289f830d



