### PR TITLE
test: re-enable delete history e2e tests 

### DIFF
--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -307,22 +307,25 @@ describe('chat', () => {
     expect(secondHistoryTitle).not.toBe('');
     expect(secondHistoryTitle).not.toBe(initialHistoryTitle);
 
-    const historyEntries = await page.getByTestId('chat-history-entry').all();
+    let historyEntries = await page.getByTestId('chat-history-entry').all();
     expect(historyEntries).toHaveLength(2);
 
-    // let deleteIcon = page.getByTestId('delete-chat-history-entry-icon').first();
-    // await deleteIcon.waitFor({ state: 'visible' });
-    // await deleteIcon.click({ force: true });
+    let deleteIcon = page.getByTestId('delete-chat-history-entry-icon').first();
+    await deleteIcon.waitFor({ state: 'visible' });
+    await deleteIcon.click({ force: true });
 
-    // historyEntries = await page.getByTestId('chat-history-entry').all();
-    // expect(historyEntries).toHaveLength(1);
+    historyEntries = await page.getByTestId('chat-history-entry').all();
+    expect(historyEntries).toHaveLength(1);
 
-    // deleteIcon = page.getByTestId('delete-chat-history-entry-icon').first();
-    // await deleteIcon.waitFor({ state: 'visible' });
-    // await deleteIcon.click({ force: true });
+    //  click on the chat to bring it into focus so the delete icon can be found
+    await historyEntries[0].click();
 
-    // historyEntries = await page.getByTestId('chat-history-entry').all();
-    // expect(historyEntries).toHaveLength(0);
+    deleteIcon = page.getByTestId('delete-chat-history-entry-icon').first();
+    await deleteIcon.waitFor({ state: 'visible' });
+    await deleteIcon.click({ force: true });
+
+    historyEntries = await page.getByTestId('chat-history-entry').all();
+    expect(historyEntries).toHaveLength(0);
   });
   test('conversation history from local storage populates the UI', async ({
     page,


### PR DESCRIPTION
## Summary
In order for the delete icon to be located, we need to either hover over the conversation title, or click it and bring it into focus


