### PR TITLE
style: alignment for assistant headers

### DIFF
--- a/src/core/components/ChatView.module.css
+++ b/src/core/components/ChatView.module.css
@@ -338,3 +338,10 @@ li {
   margin-top: var(--spacing-sm);
   height: var(--spacing-md);
 }
+
+.left h3,
+.left h4,
+.left h5,
+.left h6 {
+  margin-top: 2rem;
+}

--- a/src/core/components/ChatView.module.css
+++ b/src/core/components/ChatView.module.css
@@ -339,9 +339,7 @@ li {
   height: var(--spacing-md);
 }
 
-.left h3,
-.left h4,
-.left h5,
-.left h6 {
+.left h1, .left h2, .left h3, .left h4, .left h5, .left h6,
+.right h1, .right h2, .right h3, .right h4, .right h5, .right h6 {
   margin-top: 2rem;
 }


### PR DESCRIPTION
## Summary

Sometimes the model will respond with markdown that will get converted into elements like <h3>. We need to apply custom styling in those cases to keep it looking nice.

## Before
Header elements get margin bottom from the global style.

![Screenshot 2025-02-11 at 3 49 29 PM](https://github.com/user-attachments/assets/d465787b-3626-400a-987c-e89d09c1a77e)

## After
But if its part of the assistant response, then we should give it equal margin top.

![Screenshot 2025-02-11 at 3 51 19 PM](https://github.com/user-attachments/assets/980c3bf8-6ac2-4e10-b4e1-39eca996cf72)

