### PR TITLE
feat: chat history search (title)

### DIFF
--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -379,4 +379,75 @@ describe('chat', () => {
 
     await expect(historyEntry).toHaveText('Test Conversation Title');
   });
+
+  test('conversation search functionality', async ({ page }) => {
+    const chat = new Chat(page);
+
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        'conversations',
+        JSON.stringify({
+          'test-id-1': {
+            id: 'test-id-1',
+            model: 'test-model',
+            title: 'Blockchain Discussion',
+            conversation: [
+              {
+                role: 'user',
+                content: 'Tell me about blockchain',
+              },
+            ],
+            lastSaved: Date.now(),
+          },
+          'test-id-2': {
+            id: 'test-id-2',
+            model: 'test-model',
+            title: 'Machine Learning Chat',
+            conversation: [
+              {
+                role: 'user',
+                content: 'Explain ML concepts',
+              },
+            ],
+            lastSaved: Date.now() - 1000,
+          },
+          'test-id-3': {
+            id: 'test-id-3',
+            model: 'test-model',
+            title: 'API Integration Help',
+            conversation: [
+              {
+                role: 'user',
+                content: 'How to integrate APIs',
+              },
+            ],
+            lastSaved: Date.now() - 2000,
+          },
+        }),
+      );
+    });
+
+    await chat.goto();
+
+    const historyEntries = page.getByTestId('chat-history-entry');
+    await expect(historyEntries).toHaveCount(3);
+
+    // Search for first three letters of "Blockchain Discussion"
+    const searchInput = page.getByTestId('conversation-search-input');
+    await searchInput.fill('Blo');
+
+    const filteredEntries = page.getByTestId('chat-history-entry');
+    await expect(filteredEntries).toHaveCount(1);
+
+    const remainingEntry = filteredEntries.first();
+    await expect(remainingEntry).toHaveText('Blockchain Discussion');
+
+    // Clear the search & verify all conversations are visible again
+    await searchInput.clear();
+
+    await expect(page.getByTestId('chat-history-entry')).toHaveCount(3);
+
+    const titles = await page.getByTestId('chat-history-entry').all();
+    expect(titles).toHaveLength(3);
+  });
 });

--- a/src/core/components/ChatHistory.module.css
+++ b/src/core/components/ChatHistory.module.css
@@ -113,3 +113,32 @@
   margin-top: 14px;
   margin-left: 20px;
 }
+
+.searchInput {
+  height: 40px;
+  width: 90%;
+  background-color: var(--colors-bgTertiary);
+  border-radius: var(--borderRadius-sm);
+  border: none;
+  /* Remove top/bottom padding and use line-height for vertical centering */
+  padding: 0 var(--spacing-sm);
+  /* Set line-height equal to height for perfect vertical centering */
+  line-height: 40px;
+  color: var(--colors-textPrimary);
+  font-family: inherit;
+  font-weight: inherit;
+  overflow-y: auto;
+  resize: none;
+  text-wrap: wrap;
+
+  &:focus {
+    border: none;
+    outline: none;
+    caret-color: white;
+  }
+}
+
+.searchInputWrapper {
+  margin-top: var(--spacing-md);
+  margin-left: var(--spacing-md);
+}

--- a/src/core/components/ChatHistory.tsx
+++ b/src/core/components/ChatHistory.tsx
@@ -90,7 +90,9 @@ export const ChatHistory = ({ setChatHistoryOpen }: ChatHistoryProps) => {
     load();
     // we have to poll local storage
     const id = setInterval(load, 1000);
-    return () => clearInterval(id);
+    return () => {
+      clearInterval(id);
+    };
   }, []);
 
   const groupedHistories = useMemo(() => {

--- a/src/core/components/ChatHistory.tsx
+++ b/src/core/components/ChatHistory.tsx
@@ -80,10 +80,10 @@ export const ChatHistory = ({ setChatHistoryOpen }: ChatHistoryProps) => {
 
   useEffect(() => {
     const load = () => {
-      const storedConversations = JSON.parse(
-        localStorage.getItem('conversations') ?? '{}',
-      );
-      setConversations(Object.values(storedConversations));
+      const storedConversations = Object.values(
+        JSON.parse(localStorage.getItem('conversations') ?? '{}'),
+      ) as ConversationHistory[];
+      setConversations(storedConversations);
     };
     load();
     // we have to poll local storage

--- a/src/core/components/ChatHistory.tsx
+++ b/src/core/components/ChatHistory.tsx
@@ -8,6 +8,7 @@ import {
   Dispatch,
   SetStateAction,
   memo,
+  ChangeEvent,
 } from 'react';
 import { useAppContext } from '../context/useAppContext';
 import NewChatIcon from '../assets/NewChatIcon';
@@ -99,7 +100,7 @@ export const ChatHistory = ({ setChatHistoryOpen }: ChatHistoryProps) => {
     return groupConversations(filteredConversations);
   }, [conversations, searchTerm]);
 
-  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchTerm(e.target.value);
   };
 
@@ -166,23 +167,21 @@ export const ChatHistory = ({ setChatHistoryOpen }: ChatHistoryProps) => {
       )}
 
       <div data-testid="chat-history-section">
-        {Object.entries(groupedHistories).map(
-          ([timeGroup, groupConversations]) => (
-            <div key={timeGroup} className={styles.timeGroup}>
-              <h6 className={styles.timeGroupTitle}>{timeGroup}</h6>
-              <div className={styles.timeGroupContent}>
-                {groupConversations.map((conversation) => (
-                  <HistoryItem
-                    key={conversation.id}
-                    conversation={conversation}
-                    handleChatHistoryClick={handleChatHistoryClick}
-                    deleteConversation={deleteConversation}
-                  />
-                ))}
-              </div>
+        {Object.entries(groupedHistories).map(([timeGroup, conversations]) => (
+          <div key={timeGroup} className={styles.timeGroup}>
+            <h6 className={styles.timeGroupTitle}>{timeGroup}</h6>
+            <div className={styles.timeGroupContent}>
+              {conversations.map((conversation) => (
+                <HistoryItem
+                  key={conversation.id}
+                  conversation={conversation}
+                  handleChatHistoryClick={handleChatHistoryClick}
+                  deleteConversation={deleteConversation}
+                />
+              ))}
             </div>
-          ),
-        )}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/core/components/ChatHistory.tsx
+++ b/src/core/components/ChatHistory.tsx
@@ -210,19 +210,18 @@ const HistoryItem = memo(
     const truncateTitle = useCallback(
       (title: string) => {
         const threshold = hover ? 32 : 36;
-        let processedTitle = title;
 
-        if (processedTitle.startsWith(`"`) || processedTitle.startsWith(`'`)) {
-          processedTitle = processedTitle.slice(1);
+        if (title.startsWith(`"`) || title.startsWith(`'`)) {
+          title = title.slice(1);
         }
-        if (processedTitle.endsWith(`"`) || processedTitle.endsWith(`'`)) {
-          processedTitle = processedTitle.slice(0, -1);
+        if (title.endsWith(`"`) || title.endsWith(`'`)) {
+          title = title.slice(0, -1);
         }
-        if (processedTitle.length > threshold) {
-          processedTitle = processedTitle.slice(0, threshold) + '....';
+        if (title.length > threshold) {
+          title = title.slice(0, threshold) + '....';
         }
 
-        return processedTitle;
+        return title;
       },
       [hover],
     );

--- a/src/core/components/ChatHistory.tsx
+++ b/src/core/components/ChatHistory.tsx
@@ -63,17 +63,17 @@ export const ChatHistory = ({ setChatHistoryOpen }: ChatHistoryProps) => {
   const isMobile = useIsMobile();
 
   useEffect(() => {
-    const loadConversations = () => {
+    const load = () => {
       const storedConversations = JSON.parse(
         localStorage.getItem('conversations') ?? '{}',
       );
       setConversations(Object.values(storedConversations));
     };
+    load();
+    // we have to poll local storage
+    const id = setInterval(load, 1000);
 
-    loadConversations();
-    const intervalId = setInterval(loadConversations, 1000);
-
-    return () => clearInterval(intervalId);
+    return () => clearInterval(id);
   }, []);
 
   const groupedHistories = useMemo(() => {

--- a/src/core/components/ChatHistory.tsx
+++ b/src/core/components/ChatHistory.tsx
@@ -102,7 +102,7 @@ export const ChatHistory = ({ setChatHistoryOpen }: ChatHistoryProps) => {
     return groupConversations(filteredConversations);
   }, [conversations, searchTerm]);
 
-  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleSearchChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setSearchTerm(e.target.value);
   };
 
@@ -158,16 +158,18 @@ export const ChatHistory = ({ setChatHistoryOpen }: ChatHistoryProps) => {
         >
           <div className={styles.newChatButtonAlignment}>
             <NewChatIcon />
-            <input
-              onChange={handleSearchChange}
-              value={searchTerm}
-              placeholder="Search conversations..."
-            />
             <p className={styles.newChatButtonText}>New Chat</p>
           </div>
         </button>
       )}
-
+      <div className={styles.searchInputWrapper}>
+        <textarea
+          className={styles.searchInput}
+          onChange={handleSearchChange}
+          value={searchTerm}
+          placeholder="Search conversations..."
+        />
+      </div>
       <div data-testid="chat-history-section">
         {Object.entries(groupedHistories).map(([timeGroup, conversations]) => (
           <div key={timeGroup} className={styles.timeGroup}>

--- a/src/core/components/ChatHistory.tsx
+++ b/src/core/components/ChatHistory.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   Dispatch,
   SetStateAction,
+  memo,
 } from 'react';
 import { useAppContext } from '../context/useAppContext';
 import NewChatIcon from '../assets/NewChatIcon';
@@ -88,7 +89,6 @@ export const ChatHistory = ({ setChatHistoryOpen }: ChatHistoryProps) => {
     load();
     // we have to poll local storage
     const id = setInterval(load, 1000);
-
     return () => clearInterval(id);
   }, []);
 
@@ -193,7 +193,7 @@ interface HistoryItemProps {
   deleteConversation: (id: string) => void;
 }
 
-const HistoryItem = React.memo(
+const HistoryItem = memo(
   ({
     conversation,
     handleChatHistoryClick,
@@ -260,5 +260,3 @@ const HistoryItem = React.memo(
     );
   },
 );
-
-HistoryItem.displayName = 'HistoryItem';

--- a/src/core/components/ChatHistory.tsx
+++ b/src/core/components/ChatHistory.tsx
@@ -1,6 +1,13 @@
 import styles from './ChatHistory.module.css';
 import { ConversationHistory } from '../context/types';
-import React, { useCallback, useEffect, useState, useMemo } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useState,
+  useMemo,
+  Dispatch,
+  SetStateAction,
+} from 'react';
 import { useAppContext } from '../context/useAppContext';
 import NewChatIcon from '../assets/NewChatIcon';
 import { useIsMobile } from '../../shared/theme/useIsMobile';
@@ -8,7 +15,7 @@ import { TrashIcon } from '../assets/TrashIcon';
 import KavaAILogo from '../assets/KavaAILogo';
 
 interface ChatHistoryProps {
-  setChatHistoryOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setChatHistoryOpen: Dispatch<SetStateAction<boolean>>;
 }
 
 type GroupedConversations = {
@@ -21,17 +28,26 @@ const getTimeGroup = (timestamp: number): string => {
     (now.getTime() - timestamp) / (1000 * 60 * 60 * 24),
   );
 
-  if (diffDays === 0) return 'Today';
-  if (diffDays === 1) return 'Yesterday';
-  if (diffDays <= 7) return 'Last week';
-  if (diffDays <= 14) return '2 weeks ago';
-  if (diffDays <= 21) return '3 weeks ago';
-  if (diffDays <= 28) return '4 weeks ago';
-  if (diffDays <= 60) return 'Last month';
-  if (diffDays <= 90) return '2 months ago';
-
-  const months = Math.floor(diffDays / 30);
-  return `${months} months ago`;
+  if (diffDays === 0) {
+    return 'Today';
+  } else if (diffDays === 1) {
+    return 'Yesterday';
+  } else if (diffDays <= 7) {
+    return 'Last week';
+  } else if (diffDays <= 14) {
+    return '2 weeks ago';
+  } else if (diffDays <= 21) {
+    return '3 weeks ago';
+  } else if (diffDays <= 28) {
+    return '4 weeks ago';
+  } else if (diffDays <= 60) {
+    return 'Last month';
+  } else if (diffDays <= 90) {
+    return '2 months ago';
+  } else {
+    const months = Math.floor(diffDays / 30);
+    return `${months} months ago`;
+  }
 };
 
 const groupConversations = (
@@ -100,7 +116,7 @@ export const ChatHistory = ({ setChatHistoryOpen }: ChatHistoryProps) => {
     (id: string) => {
       const allConversations = JSON.parse(
         localStorage.getItem('conversations') ?? '{}',
-      );
+      ) as Record<string, ConversationHistory>;
 
       if (
         allConversations[id] &&
@@ -186,6 +202,7 @@ const HistoryItem = React.memo(
     const { id, title } = conversation;
     const isMobile = useIsMobile();
     const [hover, setHover] = useState(false);
+
     const { messageHistoryStore } = useAppContext();
     const isSelected = messageHistoryStore.getConversationID() === id;
 

--- a/src/core/components/ChatHistory.tsx
+++ b/src/core/components/ChatHistory.tsx
@@ -164,6 +164,7 @@ export const ChatHistory = ({ setChatHistoryOpen }: ChatHistoryProps) => {
       )}
       <div className={styles.searchInputWrapper}>
         <textarea
+          data-testid="conversation-search-input"
           className={styles.searchInput}
           onChange={handleSearchChange}
           value={searchTerm}

--- a/src/core/components/ChatView.module.css
+++ b/src/core/components/ChatView.module.css
@@ -180,6 +180,7 @@
   }
 }
 
+
 #inputContainer {
   width: 100%;
   max-width: 768px;


### PR DESCRIPTION
## Summary
- Adds an input to search/filter conversation history by title match
- Moved the conversations state into a useState hook instead of reading directly from localStorage on every render
- Added useMemo for filtering and grouping conversations
- Memoized the HistoryItem component using React.memo
- Memoized the truncateTitle function and its result


## Demo 



https://github.com/user-attachments/assets/aa816cb7-fc56-4e70-abd9-f7a0fec07320

