### PR TITLE
fix: adjust click on outside close to encompass the entire dropdown

### DIFF
--- a/src/core/components/ModelSelector.tsx
+++ b/src/core/components/ModelSelector.tsx
@@ -1,7 +1,6 @@
 import ModelDropdownButton from './ModelDropdownButton';
 import ModelDropdownExpanded from './ModelDropdownExpanded';
 import { useEffect, useState } from 'react';
-import styles from './NavBar.module.css';
 
 const ModelSelector = () => {
   const [dropdownOpen, setDropdownOpen] = useState(false);

--- a/src/core/components/ModelSelector.tsx
+++ b/src/core/components/ModelSelector.tsx
@@ -1,15 +1,18 @@
 import ModelDropdownButton from './ModelDropdownButton';
 import ModelDropdownExpanded from './ModelDropdownExpanded';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const ModelSelector = () => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const selectorRef = useRef<HTMLDivElement>(null);
 
   // Handle closing dropdown when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      const dropdown = document.querySelector(`#model-selector`);
-      if (dropdown && !dropdown.contains(event.target as Node)) {
+      if (
+        selectorRef.current &&
+        !selectorRef.current.contains(event.target as Node)
+      ) {
         setDropdownOpen(false);
       }
     };
@@ -22,7 +25,7 @@ const ModelSelector = () => {
   }, [dropdownOpen]);
 
   return (
-    <div id="model-selector">
+    <div ref={selectorRef}>
       <ModelDropdownButton
         dropdownOpen={dropdownOpen}
         setDropdownOpen={setDropdownOpen}

--- a/src/core/components/ModelSelector.tsx
+++ b/src/core/components/ModelSelector.tsx
@@ -9,8 +9,7 @@ const ModelSelector = () => {
   // Handle closing dropdown when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      const dropdown = document.querySelector(`.${styles.dropdownMenu}`);
-      console.log('dropdown', dropdown);
+      const dropdown = document.querySelector(`#model-selector`);
       if (dropdown && !dropdown.contains(event.target as Node)) {
         setDropdownOpen(false);
       }
@@ -24,7 +23,7 @@ const ModelSelector = () => {
   }, [dropdownOpen]);
 
   return (
-    <>
+    <div id="model-selector">
       <ModelDropdownButton
         dropdownOpen={dropdownOpen}
         setDropdownOpen={setDropdownOpen}
@@ -32,7 +31,7 @@ const ModelSelector = () => {
       {dropdownOpen && (
         <ModelDropdownExpanded setDropdownOpen={setDropdownOpen} />
       )}
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
Clicking the current selection was firing both close on outside click, and _then_ toggling the state back to open.

Move the locator to the parent of the dropdown

## Before

https://github.com/user-attachments/assets/396fe816-6242-4d76-852c-0aae58629f43



## After

https://github.com/user-attachments/assets/c9b6d0ba-03a7-41c9-9d00-26738818eb45


