### PR TITLE
fix: hide chat options tooltip

### DIFF
--- a/src/core/components/ChatHistory.tsx
+++ b/src/core/components/ChatHistory.tsx
@@ -252,10 +252,10 @@ const HistoryItem = memo(
             className={styles.menuIcon}
             icon={EllipsisVertical}
             size={20}
-            tooltip={{
-              text: 'Chat Options',
-              position: 'bottom',
-            }}
+            // tooltip={{
+            //   text: 'Chat Options',
+            //   position: 'bottom',
+            // }}
             data-menu-button="true"
             aria-label="Chat Options"
             onClick={handleMenuClick}


### PR DESCRIPTION
## Summary

## Demo 

## Open Questions

## Follow-on tasks
