### PR TITLE
style: edit history title input size

### DIFF
--- a/src/core/components/ChatHistory.module.css
+++ b/src/core/components/ChatHistory.module.css
@@ -78,6 +78,7 @@
   flex: 1;
   min-width: 0;
   cursor: pointer;
+  display: flex;
 }
 
 .titleContainer small {


### PR DESCRIPTION
## Summary
- add flex to edit input parent container so it can flex grow to fill available space

## Before

https://github.com/user-attachments/assets/f1d9fed9-77ea-4f86-b92b-780837f0d8aa


## After


https://github.com/user-attachments/assets/a17c3f6b-fd5c-4d1e-a897-3299fb7ab629


