### PR TITLE
feat: new chat default title

### DIFF
--- a/e2e/Chat.ts
+++ b/e2e/Chat.ts
@@ -104,4 +104,9 @@ export class Chat {
       .getByRole('option', { name: 'Blockchain Instruct' })
       .click();
   }
+
+  async switchToReasoningModel() {
+    await this.page.getByRole('combobox', { name: 'Select Model' }).click();
+    await this.page.getByRole('option', { name: 'General Reasoning' }).click();
+  }
 }

--- a/src/core/context/useMessageSaver.tsx
+++ b/src/core/context/useMessageSaver.tsx
@@ -95,12 +95,21 @@ export const useMessageSaver = (
               messages: [
                 {
                   role: 'system',
-                  content: 'Generate a 3-4 word conversation title.',
+                  content:
+                    'your task is to generate a title for a conversation using 3 to 4 words',
                 },
                 {
                   role: 'user',
-                  content: `Title suggestion for:
-                ${messages.map((msg) => `Role: ${msg.role} ${msg.content}`).join('\n')}`,
+                  content: `Please generate a title for this conversation (max 4 words):
+                  ${messages.map((msg) => {
+                    // only keep user/assistant messages
+                    if (msg.role !== 'user' && msg.role !== 'assistant') return;
+
+                    return `Role: ${msg.role} 
+                                  ${msg.content}
+                    `;
+                  })}
+                  `,
                 },
               ],
               model: 'gpt-4o-mini',

--- a/src/core/context/useMessageSaver.tsx
+++ b/src/core/context/useMessageSaver.tsx
@@ -4,96 +4,120 @@ import { ConversationHistory } from './types';
 import OpenAI from 'openai';
 import { formatConversationTitle } from '../utils/conversation/helpers';
 
+const PLACEHOLDER_CHAT_TITLE = 'New Chat';
+
 export const useMessageSaver = (
   messageHistoryStore: MessageHistoryStore,
   modelID: string,
   client: OpenAI,
 ) => {
-  // Keep track of the conversation length to detect new messages
   const prevMessageCountRef = useRef<Record<string, number>>({});
 
   useEffect(() => {
     const onChange = async () => {
       const messages = messageHistoryStore.getSnapshot();
       const id = messageHistoryStore.getConversationID();
+      const allConversations: Record<string, ConversationHistory> = JSON.parse(
+        localStorage.getItem('conversations') ?? '{}',
+      );
+
+      // Handle initial system message - save with placeholder
+      if (
+        messages.length === 1 &&
+        messages[0].role === 'system' &&
+        !allConversations[id]
+      ) {
+        // Clean up any existing empty placeholder chats
+        Object.entries(allConversations).forEach(([convId, conv]) => {
+          if (
+            conv.title === PLACEHOLDER_CHAT_TITLE &&
+            conv.conversation.length === 1
+          ) {
+            delete allConversations[convId];
+          }
+        });
+        const history: ConversationHistory = {
+          id,
+          model: modelID,
+          title: PLACEHOLDER_CHAT_TITLE,
+          conversation: messages,
+          lastSaved: new Date().valueOf(),
+        };
+        allConversations[id] = history;
+        localStorage.setItem('conversations', JSON.stringify(allConversations));
+        return;
+      }
+
+      // Clean up empty conversations with placeholder title
+      if (
+        messages.length === 1 &&
+        allConversations[id] &&
+        allConversations[id].title === PLACEHOLDER_CHAT_TITLE
+      ) {
+        delete allConversations[id];
+        localStorage.setItem('conversations', JSON.stringify(allConversations));
+        return;
+      }
 
       if (messages.length >= 3) {
         const firstUserMessage = messages.find((msg) => msg.role === 'user');
         if (!firstUserMessage) return;
-        const { content } = firstUserMessage;
 
-        const allConversations: Record<string, ConversationHistory> =
-          JSON.parse(localStorage.getItem('conversations') ?? '{}');
-
-        // Check if this is an existing conversation
         const existingConversation = allConversations[id];
-
-        // Initialize message count for this conversation if it doesn't exist
         if (!prevMessageCountRef.current[id]) {
           prevMessageCountRef.current[id] = existingConversation
             ? existingConversation.conversation.length
             : messages.length;
         }
 
-        // Determine if new messages were added to an existing conversation
         const hasNewMessages =
           existingConversation &&
           messages.length > prevMessageCountRef.current[id];
-
-        // Update the message count reference
         prevMessageCountRef.current[id] = messages.length;
 
-        // Only update lastSaved if new messages were added to an existing conversation
         const lastSaved = hasNewMessages
           ? new Date().valueOf()
           : (existingConversation?.lastSaved ?? new Date().valueOf());
 
         const history: ConversationHistory = {
           id,
-          model: existingConversation ? existingConversation.model : modelID,
-          title: content as string, // fallback value
+          model: existingConversation?.model ?? modelID,
+          title: firstUserMessage.content as string,
           conversation: messages,
           lastSaved,
         };
 
-        if (!existingConversation) {
+        // Generate title for new conversations or those with placeholder title
+        if (
+          !existingConversation ||
+          existingConversation.title === PLACEHOLDER_CHAT_TITLE
+        ) {
           try {
             const data = await client.chat.completions.create({
               stream: false,
               messages: [
                 {
                   role: 'system',
-                  content:
-                    'your task is to generate a title for a conversation using 3 to 4 words',
+                  content: 'Generate a 3-4 word conversation title.',
                 },
                 {
                   role: 'user',
-                  content: `Please generate a title for this conversation (max 4 words):
-                  ${messages.map((msg) => {
-                    // only keep user/assistant messages
-                    if (msg.role !== 'user' && msg.role !== 'assistant') return;
-
-                    return `Role: ${msg.role} 
-                                  ${msg.content}
-                    `;
-                  })}
-                  `,
+                  content: `Title suggestion for:
+                ${messages.map((msg) => `Role: ${msg.role} ${msg.content}`).join('\n')}`,
                 },
               ],
               model: 'gpt-4o-mini',
             });
-
-            // Apply truncation only when we get the AI-generated title
-            const generatedTitle =
-              data.choices[0].message.content ?? (content as string);
-            history.title = formatConversationTitle(generatedTitle, 34);
-          } catch (err) {
-            history.title = content as string;
-            console.error(err);
+            history.title = formatConversationTitle(
+              data.choices[0]?.message?.content ??
+                (firstUserMessage.content as string),
+              34,
+            );
+          } catch {
+            history.title = firstUserMessage.content as string;
           }
         } else {
-          // keep the existing title without any truncation
-          history.title = allConversations[id].title;
+          history.title = existingConversation.title;
         }
 
         allConversations[id] = history;
@@ -101,8 +125,6 @@ export const useMessageSaver = (
       }
     };
 
-    // subscribe to the store within the useEffect instead of using useSyncExternalStore
-    // this is to prevent re-renders of the caller using this hook
     const unsubscribe = messageHistoryStore.subscribe(onChange);
     return () => unsubscribe();
   }, [messageHistoryStore, modelID, client]);

--- a/src/core/context/useMessageSaver.tsx
+++ b/src/core/context/useMessageSaver.tsx
@@ -4,7 +4,7 @@ import { ConversationHistory } from './types';
 import OpenAI from 'openai';
 import { formatConversationTitle } from '../utils/conversation/helpers';
 
-const PLACEHOLDER_CHAT_TITLE = 'New Chat';
+export const PLACEHOLDER_CHAT_TITLE = 'New Chat';
 
 export const useMessageSaver = (
   messageHistoryStore: MessageHistoryStore,

--- a/src/core/context/useMessageSaver.tsx
+++ b/src/core/context/useMessageSaver.tsx
@@ -49,17 +49,6 @@ export const useMessageSaver = (
         return;
       }
 
-      // Clean up empty conversations with placeholder title
-      if (
-        messages.length === 1 &&
-        allConversations[id] &&
-        allConversations[id].title === PLACEHOLDER_CHAT_TITLE
-      ) {
-        delete allConversations[id];
-        localStorage.setItem('conversations', JSON.stringify(allConversations));
-        return;
-      }
-
       if (messages.length >= 3) {
         const firstUserMessage = messages.find((msg) => msg.role === 'user');
         if (!firstUserMessage) return;
@@ -90,7 +79,7 @@ export const useMessageSaver = (
         const history: ConversationHistory = {
           id,
           model: existingConversation?.model ?? modelID,
-          title: content as string,
+          title: content as string, //  fallback value
           conversation: messages,
           lastSaved,
         };

--- a/src/core/context/useMessageSaver.tsx
+++ b/src/core/context/useMessageSaver.tsx
@@ -114,6 +114,7 @@ export const useMessageSaver = (
               ],
               model: 'gpt-4o-mini',
             });
+
             // Apply truncation only when we get the AI-generated title
             const generatedTitle =
               data.choices[0].message.content ?? (content as string);
@@ -124,6 +125,7 @@ export const useMessageSaver = (
             console.error(err);
           }
         } else {
+          // keep the existing title without any truncation
           history.title = existingConversation.title;
         }
 


### PR DESCRIPTION
## Summary
- when a new chat is started, it is added to history with a placeholder title (New Chat)
- when a user engages with the chat and gets a response, it gets the AI-summarization as previous
- if a user starts multiple new chats or switches models without starting a chat, the previous empty chat is deleted from history

## Demo 

## Open Questions

## Follow-on tasks
