### PR TITLE
fix: add max scale to prevent zoom on inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/icon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <title>KavaAI Chat</title>
   </head>
   <body>


### PR DESCRIPTION
Without the maximum-scale set, the edit history and search input on mobile will zoom in on click, but not zoom out after typing.  This change keeps the scale the same.

Tested on iphone 15 simulator and fixes the zoom behavior.