### PR TITLE
feat: new chat placeholder applied on first user message

### DIFF
--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -287,6 +287,15 @@ describe('chat', () => {
     await chat.waitForStreamToFinish();
     await chat.waitForAssistantResponse();
 
+    //  we don't want to open a new conversation before the title generation completes
+    await page.waitForFunction(() => {
+      const historyEntry = document.querySelector(
+        '[data-testid="chat-history-entry"]:first-child',
+      );
+      const title = historyEntry?.textContent;
+      return title && title !== 'New Chat';
+    });
+
     //  Switching between conversation histories
     let blockchainQuestionConversation =
       await chat.getMessageElementsWithContent();

--- a/src/core/context/useMessageSaver.tsx
+++ b/src/core/context/useMessageSaver.tsx
@@ -80,6 +80,7 @@ export const useMessageSaver = (
         //  we shouldn't prevent a user from renaming to the placeholder
         //  also, this should only ever apply to the most recent conversation
         const isPlaceholderHistoryTitle =
+          existingConversation &&
           existingConversation.title === 'New Chat' &&
           existingConversation.conversation.length === 2 &&
           isMostRecentConversation(allConversations, id);

--- a/src/core/utils/conversation/helpers.ts
+++ b/src/core/utils/conversation/helpers.ts
@@ -189,3 +189,14 @@ const removeInitialSystemMessage = (conversation: ConversationHistory) => {
     ? conversation.conversation.slice(1)
     : conversation.conversation;
 };
+
+export const isMostRecentConversation = (
+  conversations: Record<string, ConversationHistory>,
+  currentId: string,
+): boolean => {
+  return Object.values(conversations).every(
+    (conv) =>
+      conv.id === currentId ||
+      conv.lastSaved <= conversations[currentId].lastSaved,
+  );
+};


### PR DESCRIPTION
## Summary

- "New Chat" is the history title placeholder when a user sends the first message.
-  It persists as that through the assistant streaming response 
- When the assistant's reply is finished, we do the AI summarization as previous

## Demo 

https://github.com/user-attachments/assets/58088a68-8be2-470c-a970-3e8feea08d73


