### PR TITLE
fix: delete from UI, then from local storage

### DIFF
--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -360,6 +360,7 @@ describe('chat', () => {
     await historyEntryTexts[0].waitFor({ state: 'detached' });
     historyEntryTexts = await page.getByTestId('chat-history-entry').all();
     expect(historyEntryTexts).toHaveLength(0);
+    await expect(page.getByText('Start a new chat to begin')).toBeVisible();
   });
   test('conversation history from local storage populates the UI', async ({
     page,
@@ -677,5 +678,7 @@ describe('chat', () => {
 
     const searchButton = page.getByRole('button', { name: 'Search History' });
     await expect(searchButton).toBeDisabled();
+
+    await expect(page.getByText('Start a new chat to begin')).toBeVisible();
   });
 });

--- a/src/core/components/ChatHistory.tsx
+++ b/src/core/components/ChatHistory.tsx
@@ -145,12 +145,12 @@ interface HistoryItemProps {
 
 const HistoryItem = memo(
   ({
-    conversation,
-    handleChatHistoryClick,
-    deleteConversation,
-    isMenuOpen,
-    onMenuClick,
-  }: HistoryItemProps) => {
+     conversation,
+     handleChatHistoryClick,
+     deleteConversation,
+     isMenuOpen,
+     onMenuClick,
+   }: HistoryItemProps) => {
     const { id, title } = conversation;
     const { conversationID } = useAppContext();
     const isSelected = conversationID === id;

--- a/src/core/components/ChatHistory.tsx
+++ b/src/core/components/ChatHistory.tsx
@@ -145,12 +145,12 @@ interface HistoryItemProps {
 
 const HistoryItem = memo(
   ({
-     conversation,
-     handleChatHistoryClick,
-     deleteConversation,
-     isMenuOpen,
-     onMenuClick,
-   }: HistoryItemProps) => {
+    conversation,
+    handleChatHistoryClick,
+    deleteConversation,
+    isMenuOpen,
+    onMenuClick,
+  }: HistoryItemProps) => {
     const { id, title } = conversation;
     const { conversationID } = useAppContext();
     const isSelected = conversationID === id;

--- a/src/core/components/ChatHistory.tsx
+++ b/src/core/components/ChatHistory.tsx
@@ -97,7 +97,7 @@ export const ChatHistory = ({ onHistoryItemClick }: ChatHistoryProps) => {
   return (
     <div className={styles.chatHistoryContainer}>
       <div data-testid="chat-history-section">
-        {!hasConversations ? (
+        {Object.keys(localConversations).length === 0 ? (
           <div className={styles.emptyState}>
             <Bot className={styles.emptyStateIcon} size={24} />
             <small className={styles.emptyStateText}>

--- a/src/core/components/ChatHistory.tsx
+++ b/src/core/components/ChatHistory.tsx
@@ -20,13 +20,8 @@ interface ChatHistoryProps {
 }
 
 export const ChatHistory = ({ onHistoryItemClick }: ChatHistoryProps) => {
-  const {
-    conversationID,
-    loadConversation,
-    conversations,
-    startNewChat,
-    hasConversations,
-  } = useAppContext();
+  const { conversationID, loadConversation, conversations, startNewChat } =
+    useAppContext();
 
   const conversationsToRecord = (convs: ConversationHistory[]) => {
     const record: Record<string, ConversationHistory> = {};
@@ -38,6 +33,8 @@ export const ChatHistory = ({ onHistoryItemClick }: ChatHistoryProps) => {
   const [localConversations, setLocalConversations] = useState(() =>
     conversationsToRecord(conversations),
   );
+
+  const hasLocalConversations = Object.keys(localConversations).length > 0;
 
   useEffect(() => {
     setLocalConversations(conversationsToRecord(conversations));
@@ -97,7 +94,7 @@ export const ChatHistory = ({ onHistoryItemClick }: ChatHistoryProps) => {
   return (
     <div className={styles.chatHistoryContainer}>
       <div data-testid="chat-history-section">
-        {Object.keys(localConversations).length === 0 ? (
+        {!hasLocalConversations ? (
           <div className={styles.emptyState}>
             <Bot className={styles.emptyStateIcon} size={24} />
             <small className={styles.emptyStateText}>


### PR DESCRIPTION
## Summary
This is similar to the change recently made for title editing. If a user clicks to delete a chat, we don't want to wait for a synchronous action to complete before updating the UI.

We will track conversations in local state and remove it from there first and then schedule the update to local storage.

## Before

https://github.com/user-attachments/assets/5dbade08-8683-4c8d-8ec1-c695642843c7


## After

https://github.com/user-attachments/assets/e66add22-5801-4331-b929-ea3c52c6ecf3



