### PR TITLE
fix(ci): Update get-diff-action api pattern

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -103,7 +103,7 @@ jobs:
         uses: technote-space/get-diff-action@v6
         with:
           PATTERNS: |
-            ./api/**
+            api/**
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Does a string match so having the `./` in front fails to match diff output

```bash
$ git diff '5706d4d404f71f671cbc4bcb733121f7e1a25891...85265cf6b46cbdbf39a4a7ef54e4bffa67d6d857' '--diff-filter=AMRC' --name-only
api/README.md
api/cmd/api/config/config.go
api/cmd/api/config/config_test.go
api/cmd/api/handlers/openai.go
api/cmd/api/handlers/openai_test.go
```