### PR TITLE
fix: clear message history store before switching model

### DIFF
--- a/src/core/context/AppContextProvider.tsx
+++ b/src/core/context/AppContextProvider.tsx
@@ -146,10 +146,14 @@ export const AppContextProvider = (props: {
     [conversations],
   );
 
-  const handleModelChange = useCallback((modelName: SupportedModels) => {
-    const newConfig = getModelConfig(modelName);
-    setModelConfig(newConfig);
-  }, []);
+  const handleModelChange = useCallback(
+    (modelName: SupportedModels) => {
+      messageHistoryStore.reset();
+      const newConfig = getModelConfig(modelName);
+      setModelConfig(newConfig);
+    },
+    [messageHistoryStore],
+  );
 
   const { executeOperation, isOperationValidated } = useExecuteOperation(
     registry,


### PR DESCRIPTION
## Summary
Fixes a 🪲  where switching models after an active conversation was not correctly setting the new system prompt

### Before
Notice that its talking about Kava EVM on the reasoning model

https://github.com/user-attachments/assets/c0929867-5922-41cc-a1a5-47a5ad4f59b1


### After

https://github.com/user-attachments/assets/62b36fad-8d6d-46e5-93b4-36dfb2a6ed3e


