### PR TITLE
fix: don't rename an existing conversation

### DIFF
--- a/e2e/Chat.ts
+++ b/e2e/Chat.ts
@@ -1,4 +1,4 @@
-import { ElementHandle, expect, Locator, Page } from '@playwright/test';
+import { ElementHandle, Locator, Page } from '@playwright/test';
 
 export class Chat {
   public page: Page;

--- a/src/core/context/AppContextProvider.tsx
+++ b/src/core/context/AppContextProvider.tsx
@@ -575,7 +575,7 @@ async function syncWithLocalStorage(
   const history: ConversationHistory = {
     id: conversationID,
     model: existingConversation ? existingConversation.model : id,
-    title: 'New Chat', // initial & fallback value
+    title: existingConversation ? existingConversation.title : 'New Chat', // initial & fallback value
     conversation: messages,
     lastSaved: new Date().valueOf(),
     tokensRemaining,


### PR DESCRIPTION
## Before
Gets renamed to the placeholder 

https://github.com/user-attachments/assets/8cffdda6-ad28-4a78-bb9d-30825fed1e01


## After

https://github.com/user-attachments/assets/1e18e77f-36c8-4a43-9922-833d43e10629

