### PR TITLE
feat: show context limit warning UX (demo)

### DIFF
--- a/src/core/components/ChatInput.tsx
+++ b/src/core/components/ChatInput.tsx
@@ -26,7 +26,6 @@ const ChatInput = ({
 }: ChatInputProps) => {
   const [showInputAdornmentMessage, setShowInputAdornmentMessage] =
     useState(false);
-
   const [dismissWarning, setDismissWarning] = useState(false);
 
   useManageContextWarning(

--- a/src/core/components/ChatInput.tsx
+++ b/src/core/components/ChatInput.tsx
@@ -3,8 +3,13 @@ import { CancelChatIcon, SendChatIcon } from '../assets';
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { useAppContext } from '../context/useAppContext';
 import { InputAdornmentMessage } from './InputAdornmentMessage';
+<<<<<<< HEAD
 import { ConversationHistory } from '../context/types';
 import { hasSufficientRemainingTokens } from '../utils/conversation/hasSufficientRemainingTokens';
+=======
+import { isWithinTokenLimit } from 'gpt-tokenizer';
+import { useManageContextWarning } from '../hooks/useManageContextWarning';
+>>>>>>> 46adced (feat: show input warning)
 
 const DEFAULT_HEIGHT = '30px';
 
@@ -21,6 +26,15 @@ const ChatInput = ({
 }: ChatInputProps) => {
   const [showInputAdornmentMessage, setShowInputAdornmentMessage] =
     useState(false);
+
+  const [dismissWarning, setDismissWarning] = useState(false);
+
+  useManageContextWarning(
+    dismissWarning,
+    setDismissWarning,
+    setShowInputAdornmentMessage,
+  );
+
   const [inputValue, setInputValue] = useState('');
 
   const { isRequesting, modelConfig, conversationID } = useAppContext();
@@ -115,10 +129,14 @@ const ChatInput = ({
 
   return (
     <>
-      <InputAdornmentMessage
-        showInputAdornmentMessage={showInputAdornmentMessage}
-        setShowInputAdornmentMessage={setShowInputAdornmentMessage}
-      />
+      {showInputAdornmentMessage && (
+        <InputAdornmentMessage
+          onCloseClick={() => {
+            setShowInputAdornmentMessage(false);
+            setDismissWarning(true);
+          }}
+        />
+      )}
       <div className={styles.controls}>
         <div className={styles.inputContainer}>
           <textarea

--- a/src/core/components/ChatInput.tsx
+++ b/src/core/components/ChatInput.tsx
@@ -28,7 +28,7 @@ const ChatInput = ({
     useState(false);
   const [dismissWarning, setDismissWarning] = useState(false);
 
-  useManageContextWarning(
+  const { shouldDisableChat } = useManageContextWarning(
     dismissWarning,
     setDismissWarning,
     setShowInputAdornmentMessage,
@@ -130,6 +130,7 @@ const ChatInput = ({
     <>
       {showInputAdornmentMessage && (
         <InputAdornmentMessage
+          shouldDisableChat={shouldDisableChat}
           onCloseClick={() => {
             setShowInputAdornmentMessage(false);
             setDismissWarning(true);
@@ -159,11 +160,16 @@ const ChatInput = ({
             aria-label="Send Chat"
             disabled={
               (!isRequesting && inputValue.length === 0) ||
+<<<<<<< HEAD
               !hasSufficientRemainingTokens(
                 modelConfig.id,
                 inputValue,
                 remainingContextWindow,
               )
+=======
+              !isWithinTokenLimit(inputValue, modelConfig.contextLength) ||
+              shouldDisableChat
+>>>>>>> 829815d (feat: lock out once tokens remaining is dangerously low)
             }
           >
             {isRequesting ? <CancelChatIcon /> : <SendChatIcon />}

--- a/src/core/components/ChatInput.tsx
+++ b/src/core/components/ChatInput.tsx
@@ -3,13 +3,9 @@ import { CancelChatIcon, SendChatIcon } from '../assets';
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { useAppContext } from '../context/useAppContext';
 import { InputAdornmentMessage } from './InputAdornmentMessage';
-<<<<<<< HEAD
 import { ConversationHistory } from '../context/types';
 import { hasSufficientRemainingTokens } from '../utils/conversation/hasSufficientRemainingTokens';
-=======
-import { isWithinTokenLimit } from 'gpt-tokenizer';
 import { useManageContextWarning } from '../hooks/useManageContextWarning';
->>>>>>> 46adced (feat: show input warning)
 
 const DEFAULT_HEIGHT = '30px';
 
@@ -160,16 +156,12 @@ const ChatInput = ({
             aria-label="Send Chat"
             disabled={
               (!isRequesting && inputValue.length === 0) ||
-<<<<<<< HEAD
               !hasSufficientRemainingTokens(
                 modelConfig.id,
                 inputValue,
                 remainingContextWindow,
-              )
-=======
-              !isWithinTokenLimit(inputValue, modelConfig.contextLength) ||
+              ) ||
               shouldDisableChat
->>>>>>> 829815d (feat: lock out once tokens remaining is dangerously low)
             }
           >
             {isRequesting ? <CancelChatIcon /> : <SendChatIcon />}

--- a/src/core/components/InputAdornmentMessage.module.css
+++ b/src/core/components/InputAdornmentMessage.module.css
@@ -1,29 +1,24 @@
-.cautionBanner {
+.banner {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
   padding: var(--spacing-sm);
   width: 98%;
-  background-color: var(--colors-accentTwoMuted);
   font-size: 1.1rem;
   color: var(--colors-textPrimary);
   margin-bottom: -1rem;
   border-radius: var(--borderRadius-sm);
+}
+
+.cautionBanner {
+  composes: banner;
+  background-color: var(--colors-accentTwoMuted);
 }
 
 .warningBanner {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-sm);
-  width: 98%;
+  composes: banner;
   background-color: var(--colors-accentMuted);
-  font-size: 1.1rem;
-  color: var(--colors-textPrimary);
-  margin-bottom: -1rem;
-  border-radius: var(--borderRadius-sm);
 }
-
 
 .message {
   flex: 1;

--- a/src/core/components/InputAdornmentMessage.module.css
+++ b/src/core/components/InputAdornmentMessage.module.css
@@ -1,4 +1,4 @@
-.banner {
+.cautionBanner {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
@@ -10,6 +10,20 @@
   margin-bottom: -1rem;
   border-radius: var(--borderRadius-sm);
 }
+
+.warningBanner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  width: 98%;
+  background-color: var(--colors-accentMuted);
+  font-size: 1.1rem;
+  color: var(--colors-textPrimary);
+  margin-bottom: -1rem;
+  border-radius: var(--borderRadius-sm);
+}
+
 
 .message {
   flex: 1;
@@ -40,4 +54,8 @@
 
 .closeIcon:hover {
   background: none;
+}
+
+.hiddenCloseIcon {
+  visibility: hidden;
 }

--- a/src/core/components/InputAdornmentMessage.tsx
+++ b/src/core/components/InputAdornmentMessage.tsx
@@ -45,6 +45,7 @@ export const InputAdornmentMessage: React.FC<InputAdornmentMessageProps> = ({
           aria-label="Close New Chat Prompt"
           className={closeIconStyle}
           onClick={onCloseClick}
+          disabled={shouldDisableChat}
         />
       </div>
     </div>

--- a/src/core/components/InputAdornmentMessage.tsx
+++ b/src/core/components/InputAdornmentMessage.tsx
@@ -5,17 +5,13 @@ import { X as CloseX } from 'lucide-react';
 import { useAppContext } from '../context/useAppContext';
 
 interface InputAdornmentMessageProps {
-  showInputAdornmentMessage: boolean;
-  setShowInputAdornmentMessage: (show: boolean) => void;
+  onCloseClick: () => void;
 }
 
 export const InputAdornmentMessage: React.FC<InputAdornmentMessageProps> = ({
-  showInputAdornmentMessage,
-  setShowInputAdornmentMessage,
+  onCloseClick,
 }) => {
   const { startNewChat } = useAppContext();
-
-  if (!showInputAdornmentMessage) return null;
 
   return (
     <div className={styles.wrapper}>
@@ -35,7 +31,7 @@ export const InputAdornmentMessage: React.FC<InputAdornmentMessageProps> = ({
           size={12}
           aria-label="Close New Chat Prompt"
           className={styles.closeIcon}
-          onClick={() => setShowInputAdornmentMessage(false)}
+          onClick={onCloseClick}
         />
       </div>
     </div>

--- a/src/core/components/InputAdornmentMessage.tsx
+++ b/src/core/components/InputAdornmentMessage.tsx
@@ -23,7 +23,7 @@ export const InputAdornmentMessage: React.FC<InputAdornmentMessageProps> = ({
     ? styles.warningBanner
     : styles.cautionBanner;
 
-  //  give user option to close, only start new chat
+  //  don't give user option to close, only start new chat
   const closeIconStyle = shouldDisableChat
     ? styles.hiddenCloseIcon
     : styles.closeIcon;

--- a/src/core/components/InputAdornmentMessage.tsx
+++ b/src/core/components/InputAdornmentMessage.tsx
@@ -6,19 +6,32 @@ import { useAppContext } from '../context/useAppContext';
 
 interface InputAdornmentMessageProps {
   onCloseClick: () => void;
+  shouldDisableChat: boolean;
 }
 
 export const InputAdornmentMessage: React.FC<InputAdornmentMessageProps> = ({
   onCloseClick,
+  shouldDisableChat,
 }) => {
   const { startNewChat } = useAppContext();
 
+  const warningText = shouldDisableChat
+    ? 'This conversation has exceeded the context limit'
+    : 'This conversation is approaching the context limit';
+
+  const bannerStyle = shouldDisableChat
+    ? styles.warningBanner
+    : styles.cautionBanner;
+
+  //  give user option to close, only start new chat
+  const closeIconStyle = shouldDisableChat
+    ? styles.hiddenCloseIcon
+    : styles.closeIcon;
+
   return (
     <div className={styles.wrapper}>
-      <div className={styles.banner}>
-        <span className={styles.message}>
-          This conversation has exceeded the context limit
-        </span>
+      <div className={bannerStyle}>
+        <span className={styles.message}>{warningText}</span>
         <button
           onClick={startNewChat}
           aria-label="Start New Chat Button"
@@ -30,7 +43,7 @@ export const InputAdornmentMessage: React.FC<InputAdornmentMessageProps> = ({
           icon={CloseX}
           size={12}
           aria-label="Close New Chat Prompt"
-          className={styles.closeIcon}
+          className={closeIconStyle}
           onClick={onCloseClick}
         />
       </div>

--- a/src/core/hooks/useManageContextWarning.ts
+++ b/src/core/hooks/useManageContextWarning.ts
@@ -1,13 +1,24 @@
 import { useEffect } from 'react';
 import { useAppContext } from '../context/useAppContext';
 import { ConversationHistory } from '../context/types';
+import { ModelConfig } from '../types/models';
+
+const isBelowContextThreshold = (
+  conversation: ConversationHistory,
+  modelConfig: ModelConfig,
+) => {
+  const { tokensRemaining } = conversation;
+  const { contextLength, contextThresholdPercentage } = modelConfig;
+
+  return (tokensRemaining / contextLength) * 100 <= contextThresholdPercentage;
+};
 
 export const useManageContextWarning = (
   dismissWarning: boolean,
   setDismissWarning: (dismiss: boolean) => void,
   setShowInputAdornmentMessage: (show: boolean) => void,
 ) => {
-  const { conversationID } = useAppContext();
+  const { conversationID, modelConfig } = useAppContext();
 
   const allConversations: Record<string, ConversationHistory> = JSON.parse(
     localStorage.getItem('conversations') ?? '{}',
@@ -27,11 +38,15 @@ export const useManageContextWarning = (
   useEffect(() => {
     if (
       currentConversation &&
-      //  todo - determine threshold
-      // currentConversation.tokensRemaining <  &&
-      !dismissWarning
+      !dismissWarning &&
+      isBelowContextThreshold(currentConversation, modelConfig)
     ) {
-      // setShowInputAdornmentMessage(true);
+      setShowInputAdornmentMessage(true);
     }
-  }, [currentConversation, dismissWarning, setShowInputAdornmentMessage]);
+  }, [
+    currentConversation,
+    dismissWarning,
+    modelConfig,
+    setShowInputAdornmentMessage,
+  ]);
 };

--- a/src/core/hooks/useManageContextWarning.ts
+++ b/src/core/hooks/useManageContextWarning.ts
@@ -28,10 +28,10 @@ export const useManageContextWarning = (
     if (
       currentConversation &&
       //  todo - determine threshold
-      currentConversation.tokensRemaining < 1000000 &&
+      // currentConversation.tokensRemaining <  &&
       !dismissWarning
     ) {
-      setShowInputAdornmentMessage(true);
+      // setShowInputAdornmentMessage(true);
     }
   }, [currentConversation, dismissWarning, setShowInputAdornmentMessage]);
 };

--- a/src/core/hooks/useManageContextWarning.ts
+++ b/src/core/hooks/useManageContextWarning.ts
@@ -33,7 +33,7 @@ export const useManageContextWarning = (
     setDismissWarning(false);
   }, [conversationID, setDismissWarning, setShowInputAdornmentMessage]);
 
-  //  when an existing conversation goes over the threshold,
+  //  when an existing conversation goes below the threshold,
   //  show the warning, provided the user hasn't already seen it and toggled it off
   useEffect(() => {
     if (

--- a/src/core/hooks/useManageContextWarning.ts
+++ b/src/core/hooks/useManageContextWarning.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { useAppContext } from '../context/useAppContext';
+import { ConversationHistory } from '../context/types';
+
+export const useManageContextWarning = (
+  dismissWarning: boolean,
+  setDismissWarning: (dismiss: boolean) => void,
+  setShowInputAdornmentMessage: (show: boolean) => void,
+) => {
+  const { conversationID } = useAppContext();
+
+  const allConversations: Record<string, ConversationHistory> = JSON.parse(
+    localStorage.getItem('conversations') ?? '{}',
+  );
+
+  const currentConversation = allConversations[conversationID];
+
+  //  when a user changes to another conversation or starts a new one,
+  //  reset dismissal so they get the warning
+  useEffect(() => {
+    setDismissWarning(false);
+  }, [conversationID, setDismissWarning]);
+
+  //  when an existing conversation goes over the threshold,
+  //  show the warning, provided the user hasn't already seen it and toggled it off
+  useEffect(() => {
+    if (
+      currentConversation &&
+      //  todo - determine threshold
+      // currentConversation.tokensRemaining < ? &&
+      !dismissWarning
+    ) {
+      // setShowInputAdornmentMessage(true);
+    }
+  }, [currentConversation, dismissWarning, setShowInputAdornmentMessage]);
+};

--- a/src/core/hooks/useManageContextWarning.ts
+++ b/src/core/hooks/useManageContextWarning.ts
@@ -15,11 +15,12 @@ export const useManageContextWarning = (
 
   const currentConversation = allConversations[conversationID];
 
-  //  when a user changes to another conversation or starts a new one,
-  //  reset dismissal so they get the warning
+  //  when a user changes to another conversation (existing or new),
+  //  reset all state
   useEffect(() => {
+    setShowInputAdornmentMessage(false);
     setDismissWarning(false);
-  }, [conversationID, setDismissWarning]);
+  }, [conversationID, setDismissWarning, setShowInputAdornmentMessage]);
 
   //  when an existing conversation goes over the threshold,
   //  show the warning, provided the user hasn't already seen it and toggled it off

--- a/src/core/hooks/useManageContextWarning.ts
+++ b/src/core/hooks/useManageContextWarning.ts
@@ -27,10 +27,10 @@ export const useManageContextWarning = (
     if (
       currentConversation &&
       //  todo - determine threshold
-      // currentConversation.tokensRemaining < ? &&
+      currentConversation.tokensRemaining < 1000000 &&
       !dismissWarning
     ) {
-      // setShowInputAdornmentMessage(true);
+      setShowInputAdornmentMessage(true);
     }
   }, [currentConversation, dismissWarning, setShowInputAdornmentMessage]);
 };

--- a/src/core/hooks/useManageContextWarning.ts
+++ b/src/core/hooks/useManageContextWarning.ts
@@ -39,8 +39,9 @@ export const useManageContextWarning = (
   //  show the warning, provided the user hasn't already seen it and toggled it off,
   //  but override that preference when they get dangerously low
   const dangerouslyLowContext =
+    currentConversation &&
     currentConversation.tokensRemaining <
-    modelConfig.conversationResetThreshold;
+      modelConfig.conversationResetThreshold;
 
   useEffect(() => {
     const shouldShowWarning =

--- a/src/core/hooks/useManageContextWarning.ts
+++ b/src/core/hooks/useManageContextWarning.ts
@@ -52,6 +52,7 @@ export const useManageContextWarning = (
     setShowInputAdornmentMessage(shouldShowWarning);
   }, [
     currentConversation,
+    dangerouslyLowContext,
     dismissWarning,
     modelConfig,
     setShowInputAdornmentMessage,

--- a/src/core/hooks/useManageContextWarning.ts
+++ b/src/core/hooks/useManageContextWarning.ts
@@ -41,7 +41,7 @@ export const useManageContextWarning = (
   const dangerouslyLowContext =
     currentConversation &&
     currentConversation.tokensRemaining <
-      modelConfig.conversationResetThreshold;
+      modelConfig.conversationResetTokenThreshold;
 
   useEffect(() => {
     const shouldShowWarning =

--- a/src/core/types/models.ts
+++ b/src/core/types/models.ts
@@ -23,7 +23,7 @@ export interface BaseModelConfig {
     finalChunk?: ChatCompletionChunk,
   ) => Promise<ContextMetrics>;
   contextWarningThresholdPercentage: number;
-  conversationResetThreshold: number;
+  conversationResetTokenThreshold: number;
   tools: ChatCompletionTool[];
   systemPrompt: string;
   introText: string;

--- a/src/core/types/models.ts
+++ b/src/core/types/models.ts
@@ -22,6 +22,7 @@ export interface BaseModelConfig {
     contextLength: number,
     finalChunk?: ChatCompletionChunk,
   ) => Promise<ContextMetrics>;
+  contextThresholdPercentage: number;
   tools: ChatCompletionTool[];
   systemPrompt: string;
   introText: string;

--- a/src/core/types/models.ts
+++ b/src/core/types/models.ts
@@ -22,7 +22,8 @@ export interface BaseModelConfig {
     contextLength: number,
     finalChunk?: ChatCompletionChunk,
   ) => Promise<ContextMetrics>;
-  contextThresholdPercentage: number;
+  contextWarningThresholdPercentage: number;
+  conversationResetThreshold: number;
   tools: ChatCompletionTool[];
   systemPrompt: string;
   introText: string;

--- a/src/core/utils/conversation/helpers.test.ts
+++ b/src/core/utils/conversation/helpers.test.ts
@@ -355,7 +355,7 @@ describe('formatContentSnippet', () => {
   });
 });
 
-describe('calculateContextMetrics', () => {
+describe('calculateGptContextMetrics', () => {
   const maxTokens = blockchainModels['gpt-4o'].contextLength;
 
   it('initializing with system prompt', async () => {

--- a/src/core/utils/conversation/helpers.ts
+++ b/src/core/utils/conversation/helpers.ts
@@ -197,7 +197,7 @@ const removeInitialSystemMessage = (conversation: ConversationHistory) => {
 /**
  *
  * Function to calculate context metrics based on messages and model's context length
- * @param chatMessages  The conversation
+ * @param chatMessages  Array of chat messages
  * @param contextLength maximum tokens per conversation
  * @returns ContextMetrics object (promise)
  */

--- a/src/core/utils/conversation/helpers.ts
+++ b/src/core/utils/conversation/helpers.ts
@@ -197,7 +197,7 @@ const removeInitialSystemMessage = (conversation: ConversationHistory) => {
 /**
  *
  * Function to calculate context metrics based on messages and model's context length
- * @param messages Array of chat messages
+ * @param chatMessages  The conversation
  * @param contextLength maximum tokens per conversation
  * @returns ContextMetrics object (promise)
  */

--- a/src/core/utils/conversation/helpers.ts
+++ b/src/core/utils/conversation/helpers.ts
@@ -198,7 +198,6 @@ const removeInitialSystemMessage = (conversation: ConversationHistory) => {
  *
  * Function to calculate context metrics based on messages and model's context length
  * @param chatMessages  Array of chat messages
- * @param contextLength maximum tokens per conversation
  * @returns ContextMetrics object (promise)
  */
 export async function calculateGptContextMetrics(

--- a/src/features/blockchain/config/models.ts
+++ b/src/features/blockchain/config/models.ts
@@ -28,7 +28,7 @@ export const blockchainModels: Record<
     contextLength: 128000,
     contextLimitMonitor: calculateGptContextMetrics,
     contextWarningThresholdPercentage: 5,
-    conversationResetThreshold: 100,
+    conversationResetTokenThreshold: 100,
     systemPrompt: messageRegistry.getSystemPrompt(),
     introText: messageRegistry.getIntroText(),
     inputPlaceholderText: messageRegistry.getInputPlaceholderText(),

--- a/src/features/blockchain/config/models.ts
+++ b/src/features/blockchain/config/models.ts
@@ -27,7 +27,8 @@ export const blockchainModels: Record<
     //  https://platform.openai.com/docs/models#gpt-4o
     contextLength: 128000,
     contextLimitMonitor: calculateGptContextMetrics,
-    contextThresholdPercentage: 5,
+    contextWarningThresholdPercentage: 5,
+    conversationResetThreshold: 100,
     systemPrompt: messageRegistry.getSystemPrompt(),
     introText: messageRegistry.getIntroText(),
     inputPlaceholderText: messageRegistry.getInputPlaceholderText(),

--- a/src/features/blockchain/config/models.ts
+++ b/src/features/blockchain/config/models.ts
@@ -27,6 +27,7 @@ export const blockchainModels: Record<
     //  https://platform.openai.com/docs/models#gpt-4o
     contextLength: 128000,
     contextLimitMonitor: calculateGptContextMetrics,
+    contextThresholdPercentage: 5,
     systemPrompt: messageRegistry.getSystemPrompt(),
     introText: messageRegistry.getIntroText(),
     inputPlaceholderText: messageRegistry.getInputPlaceholderText(),

--- a/src/features/reasoning/config/models.ts
+++ b/src/features/reasoning/config/models.ts
@@ -23,7 +23,7 @@ export const reasoningModels: Record<
     contextLength: 8192,
     contextLimitMonitor: calculateDeepseekTokenUsage,
     contextWarningThresholdPercentage: 5,
-    conversationResetThreshold: 100,
+    conversationResetTokenThreshold: 100,
     systemPrompt: defaultSystemPrompt,
     introText: defaultIntroText,
     inputPlaceholderText: defaultInputPlaceholderText,

--- a/src/features/reasoning/config/models.ts
+++ b/src/features/reasoning/config/models.ts
@@ -22,6 +22,7 @@ export const reasoningModels: Record<
     //  not running full 128K token context currently
     contextLength: 8192,
     contextLimitMonitor: calculateDeepseekTokenUsage,
+    contextThresholdPercentage: 5,
     systemPrompt: defaultSystemPrompt,
     introText: defaultIntroText,
     inputPlaceholderText: defaultInputPlaceholderText,

--- a/src/features/reasoning/config/models.ts
+++ b/src/features/reasoning/config/models.ts
@@ -22,7 +22,8 @@ export const reasoningModels: Record<
     //  not running full 128K token context currently
     contextLength: 8192,
     contextLimitMonitor: calculateDeepseekTokenUsage,
-    contextThresholdPercentage: 5,
+    contextWarningThresholdPercentage: 5,
+    conversationResetThreshold: 100,
     systemPrompt: defaultSystemPrompt,
     introText: defaultIntroText,
     inputPlaceholderText: defaultInputPlaceholderText,

--- a/src/shared/theme/themes.ts
+++ b/src/shared/theme/themes.ts
@@ -22,6 +22,7 @@ export interface ThemeColors {
   accent: string;
   accentTransparent: string;
   accentBorder: string;
+  accentMuted?: string;
   accentTwo?: string;
   accentTwoTransparent?: string;
   accentTwoBorder?: string;
@@ -83,6 +84,7 @@ export const baseTheme: Theme = {
     textMuted: 'rgb(150, 150, 150)',
     accent: 'rgb(255, 67, 62)',
     accentTransparent: 'rgba(255, 67, 62, 0.75)',
+    accentMuted: 'rgba(255, 67, 62, 0.5)',
     accentTwo: 'rgb(147, 130, 215)',
     accentTwoTransparent: 'rgba(147, 130, 215, 0.75)',
     accentTwoMuted: 'rgba(147, 130, 215, 0.4)',

--- a/src/shared/theme/themes.ts
+++ b/src/shared/theme/themes.ts
@@ -84,7 +84,7 @@ export const baseTheme: Theme = {
     textMuted: 'rgb(150, 150, 150)',
     accent: 'rgb(255, 67, 62)',
     accentTransparent: 'rgba(255, 67, 62, 0.75)',
-    accentMuted: 'rgba(255, 67, 62, 0.5)',
+    accentMuted: 'rgba(255, 67, 62, 0.4)',
     accentTwo: 'rgb(147, 130, 215)',
     accentTwoTransparent: 'rgba(147, 130, 215, 0.75)',
     accentTwoMuted: 'rgba(147, 130, 215, 0.4)',


### PR DESCRIPTION
## Summary
- when a user crosses a threshold of token usage for a conversation, the warning is shown
- the user can close the warning and it won't be shown again while that conversation remains in view
- if the user returns to that conversation later, the warning will be shown (we aren't storing that preference on the conversation history)

## Demo 


https://github.com/user-attachments/assets/dec4e6e3-0259-4cb9-9c32-797218c0269c

## Limit Reached
- Warning shown
- no close icon (just start new chat)
- send button disabled

![Screenshot 2025-02-27 at 12 50 42 PM](https://github.com/user-attachments/assets/bc6a6d2d-fba6-4ab6-a47d-e4d4dcdc982d)



