### PR TITLE
fix: reset system prompt on model change

### DIFF
--- a/src/core/context/AppContextProvider.tsx
+++ b/src/core/context/AppContextProvider.tsx
@@ -230,10 +230,6 @@ export const AppContextProvider = (props: {
     setIsReady(true);
   }, []);
 
-  useEffect(() => {
-    ensureCorrectSystemPrompt(messageHistoryStore, modelConfig);
-  }, [messageHistoryStore, modelConfig, ensureCorrectSystemPrompt]);
-
   // abort controller for cancelling openai request
   const controllerRef = useRef<AbortController | null>(null);
 

--- a/src/core/context/AppContextProvider.tsx
+++ b/src/core/context/AppContextProvider.tsx
@@ -183,7 +183,7 @@ export const AppContextProvider = (props: {
         ensureCorrectSystemPrompt(messageHistoryStore, newConfig);
       }
     },
-    [messageHistoryStore],
+    [messageHistoryStore, ensureCorrectSystemPrompt],
   );
 
   const { executeOperation, isOperationValidated } = useExecuteOperation(
@@ -213,7 +213,7 @@ export const AppContextProvider = (props: {
     const newConv = newConversation();
     ensureCorrectSystemPrompt(newConv.messageHistoryStore, modelConfig);
     setConversation(newConv);
-  }, []);
+  }, [modelConfig, ensureCorrectSystemPrompt]);
 
   useEffect(() => {
     try {
@@ -232,7 +232,7 @@ export const AppContextProvider = (props: {
 
   useEffect(() => {
     ensureCorrectSystemPrompt(messageHistoryStore, modelConfig);
-  }, [messageHistoryStore, modelConfig]);
+  }, [messageHistoryStore, modelConfig, ensureCorrectSystemPrompt]);
 
   // abort controller for cancelling openai request
   const controllerRef = useRef<AbortController | null>(null);
@@ -335,13 +335,6 @@ export const AppContextProvider = (props: {
     }
   }, [toolCallStreamStore]);
 
-  const handleReset = useCallback(() => {
-    handleCancel();
-    messageHistoryStore.setMessages([
-      { role: 'system' as const, content: modelConfig.systemPrompt },
-    ]);
-  }, [handleCancel, messageHistoryStore, modelConfig.systemPrompt]);
-
   return (
     <AppContext.Provider
       value={{
@@ -355,7 +348,6 @@ export const AppContextProvider = (props: {
         modelConfig,
         handleModelChange,
         startNewChat,
-        handleReset,
         handleCancel,
         handleChatCompletion,
         thinkingStore,

--- a/src/core/context/types.ts
+++ b/src/core/context/types.ts
@@ -41,7 +41,6 @@ export type AppContextType = {
   handleModelChange: (modelName: SupportedModels) => void;
   startNewChat: () => void;
   executeOperation: ExecuteOperation;
-  handleReset: () => void;
   handleChatCompletion: (value: string) => void;
   handleCancel: () => void;
   walletStore: WalletStore;


### PR DESCRIPTION
## Summary
- check and reset message history with system prompt when model change

## Demo 

## Open Questions

## Follow-on tasks
