### PR TITLE
feat(api): Enable local docker compose testing

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -26,7 +26,7 @@ KAVACHAT_API_PORT=8080
 KAVACHAT_API_HOST=127.0.0.1
 KAVACHAT_API_METRICS_PORT=9090
 KAVACHAT_API_PUBLIC_URL=https://public-url.com
-KAVACHAT_API_S3_BUCKET=your-bucket-name
+KAVACHAT_API_S3_BUCKET=test-bucket
 
 KAVACHAT_API_BACKEND_0_NAME=OpenAI
 KAVACHAT_API_BACKEND_0_BASE_URL=https://openai-compatible/endpoint
@@ -42,3 +42,17 @@ KAVACHAT_API_BACKEND_1_BASE_URL=https://your-endpoint
 KAVACHAT_API_BACKEND_1_API_KEY=your-api-key
 KAVACHAT_API_BACKEND_1_ALLOWED_MODELS=other,models
 ```
+
+## Local Development
+
+File uploads use localstack for S3. You can start localstack with docker compose
+and the [docker-compose.yaml](../docker-compose.yaml) file in the root of the
+repository.
+
+```bash
+docker compose up localstack
+```
+
+Note that localstack initialization creates a bucket with the name `test-bucket`.
+
+Initialization files can be found in the root [`./aws`](../aws/) directory.

--- a/api/cmd/api/config/config.go
+++ b/api/cmd/api/config/config.go
@@ -20,7 +20,8 @@ type Config struct {
 	LogFormat   string `env:"LOG_FORMAT" envDefault:"plain"`
 
 	// File Uploads
-	S3BucketName string `env:"S3_BUCKET"`
+	S3BucketName        string `env:"S3_BUCKET"`
+	S3PathStyleRequests bool   `env:"S3_PATH_STYLE_REQUESTS" envDefault:"false"`
 
 	Backends OpenAIBackends `envPrefix:"BACKEND"`
 }

--- a/api/cmd/api/handlers/files_download.go
+++ b/api/cmd/api/handlers/files_download.go
@@ -27,6 +27,7 @@ type FileDownloadHandler struct {
 // NewFileDownloadHandler creates a new FileDownloadHandler with the given bucket name.
 func NewFileDownloadHandler(
 	bucketName string,
+	s3PathStyleRequests bool,
 	baseLogger *zerolog.Logger,
 ) *FileDownloadHandler {
 	logger := baseLogger.With().
@@ -39,7 +40,9 @@ func NewFileDownloadHandler(
 		panic(fmt.Sprintf("unable to load AWS SDK config: %v", err))
 	}
 
-	client := s3.NewFromConfig(cfg)
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.UsePathStyle = s3PathStyleRequests
+	})
 
 	return &FileDownloadHandler{
 		s3Client:   client,

--- a/api/cmd/api/handlers/files_upload.go
+++ b/api/cmd/api/handlers/files_upload.go
@@ -50,6 +50,7 @@ type FileUploadHandler struct {
 // NewFileUploadHandler creates a new FileUploadHandler with the given bucket name,
 func NewFileUploadHandler(
 	bucketName string,
+	s3PathStyleRequests bool,
 	publicURL string,
 	baseLogger *zerolog.Logger,
 ) *FileUploadHandler {
@@ -63,7 +64,9 @@ func NewFileUploadHandler(
 		panic(fmt.Sprintf("unable to load AWS SDK config: %v", err))
 	}
 
-	client := s3.NewFromConfig(cfg)
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.UsePathStyle = s3PathStyleRequests
+	})
 
 	return &FileUploadHandler{
 		s3Client:   client,

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -114,6 +114,7 @@ func main() {
 			fileMetrics,
 		).Then(handlers.NewFileUploadHandler(
 			cfg.S3BucketName,
+			cfg.S3PathStyleRequests,
 			cfg.PublicURL,
 			logger,
 		)),
@@ -126,6 +127,7 @@ func main() {
 			fileMetrics,
 		).Then(handlers.NewFileDownloadHandler(
 			cfg.S3BucketName,
+			cfg.S3PathStyleRequests,
 			logger,
 		)),
 	)

--- a/aws/buckets.sh
+++ b/aws/buckets.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+awslocal configure set region us-east-1
+
 BUCKET_NAME="test-bucket"
 
 # Create bucket for file upload tests

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,11 +11,17 @@ services:
       KAVACHAT_API_HOST: '0.0.0.0'
       KAVACHAT_API_BACKEND_0_NAME: 'OpenAI'
 
-      # localstack: localhost may fail with hostname resolution error
+      # Localstack
       AWS_ENDPOINT_URL: http://localstack:4566
-      # file support
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+
+      # File support
       KAVACHAT_API_PUBLIC_URL: http://localhost:5555
       KAVACHAT_API_S3_BUCKET: test-bucket
+      # Use path-style requests for localstack to avoid DNS issues
+      KAVACHAT_API_S3_PATH_STYLE_REQUESTS: true
 
       # Pass through existing environment variables
       KAVACHAT_API_BACKEND_0_BASE_URL: ${OPENAI_BASE_URL}


### PR DESCRIPTION
## Summary
- Configurable path style S3 requests (for less issues with subdomains and networking on docker)
- Add docker compose env vars for localstack