### PR TITLE
refactor: adjust `ContextMetrics` properties

### DIFF
--- a/src/core/types/models.ts
+++ b/src/core/types/models.ts
@@ -65,7 +65,5 @@ export interface ModelRegistry {
 }
 
 export interface ContextMetrics {
-  tokensUsed: number;
   tokensRemaining: number;
-  percentageRemaining: number;
 }

--- a/src/core/utils/conversation/helpers.test.ts
+++ b/src/core/utils/conversation/helpers.test.ts
@@ -365,9 +365,7 @@ describe('calculateGptContextMetrics', () => {
     const result = await calculateGptContextMetrics(mockMessages);
 
     expect(result).toEqual({
-      tokensUsed: 10, //  amount from the system prompt
       tokensRemaining: maxTokens - 10,
-      percentageRemaining: 99.9,
     });
   });
 
@@ -382,9 +380,7 @@ describe('calculateGptContextMetrics', () => {
     const result = await calculateGptContextMetrics(mockMessages);
 
     expect(result).toEqual({
-      tokensUsed: 25, //  additional tokens used
       tokensRemaining: maxTokens - 25,
-      percentageRemaining: 99.9,
     });
 
     const updatedMessages: ChatMessage[] = [
@@ -395,9 +391,7 @@ describe('calculateGptContextMetrics', () => {
     const updatedResult = await calculateGptContextMetrics(updatedMessages);
 
     expect(updatedResult).toEqual({
-      tokensUsed: 34, //  more tokens used
       tokensRemaining: maxTokens - 34,
-      percentageRemaining: 99.9,
     });
   });
 
@@ -408,9 +402,7 @@ describe('calculateGptContextMetrics', () => {
     const result = await calculateGptContextMetrics(mockMessages);
 
     expect(result).toEqual({
-      tokensUsed: 120007,
       tokensRemaining: maxTokens - 120007,
-      percentageRemaining: 6.2,
     });
   });
 });

--- a/src/core/utils/conversation/helpers.ts
+++ b/src/core/utils/conversation/helpers.ts
@@ -208,18 +208,7 @@ export async function calculateGptContextMetrics(
   const tokensUsed = encodeChat(messages, 'gpt-4o').length;
   const tokensRemaining = Math.max(0, maxTokens - tokensUsed);
 
-  let percentageRemaining = Number(
-    ((tokensRemaining / maxTokens) * 100).toFixed(1),
-  );
-
-  // Adjust percentage if tokens have been used to avoid rounding to 100%
-  if (tokensUsed > 0 && percentageRemaining === 100.0) {
-    percentageRemaining = 99.9;
-  }
-
   return {
-    tokensUsed,
     tokensRemaining,
-    percentageRemaining,
   };
 }

--- a/src/features/reasoning/helpers.ts
+++ b/src/features/reasoning/helpers.ts
@@ -57,17 +57,7 @@ export async function calculateDeepseekTokenUsage(
     tokensRemaining = Math.max(0, contextLength - estimatedUsage.totalTokens);
   }
 
-  const tokensUsed = contextLength - tokensRemaining;
-  const percentageRemaining = Number(
-    ((tokensRemaining / contextLength) * 100).toFixed(1),
-  );
-
   return {
-    tokensUsed,
     tokensRemaining,
-    percentageRemaining:
-      tokensUsed > 0 && percentageRemaining === 100.0
-        ? 99.9
-        : percentageRemaining,
   };
 }


### PR DESCRIPTION
## Summary
We only need to store `tokensRemaining` on ChatHistory in local storage and can derive any other information from the model config. This removes these unused properties on the `ContextMetrics` type


