### PR TITLE
fix: prior reasoning content should persist in the UI

### DIFF
--- a/src/core/context/AppContextProvider.tsx
+++ b/src/core/context/AppContextProvider.tsx
@@ -351,11 +351,15 @@ async function doChat(
   progressStore.setText('Thinking');
   const { id, tools } = modelConfig;
   try {
-    const messages = messageHistoryStore.getSnapshot().map((msg) => {
-      if ('reasoningContent' in msg) {
-        delete msg.reasoningContent;
+    // Create a copy of messages without reasoningContent for the API call
+    // but don't modify the original messages in the store
+    const apiMessages = messageHistoryStore.getSnapshot().map((msg) => {
+      // Create a shallow copy to avoid modifying the original
+      const msgCopy = { ...msg };
+      if ('reasoningContent' in msgCopy) {
+        delete msgCopy.reasoningContent;
       }
-      return msg;
+      return msgCopy;
     });
 
     let finalChunk: ChatCompletionChunk | undefined;
@@ -363,7 +367,7 @@ async function doChat(
     const stream = await client.chat.completions.create(
       {
         model: id,
-        messages: messages,
+        messages: apiMessages, // Use the copy without reasoning content
         tools: tools,
         stream: true,
       },

--- a/src/core/context/AppContextProvider.tsx
+++ b/src/core/context/AppContextProvider.tsx
@@ -351,22 +351,24 @@ async function doChat(
   progressStore.setText('Thinking');
   const { id, tools } = modelConfig;
   try {
-    // Create a copy of messages without reasoningContent for the API call
+    // Create a copy of messages without reasoningContent to stream to the model
     // but don't modify the original messages in the store which we will render to the UI
-    const apiMessages = messageHistoryStore.getSnapshot().map((msg) => {
-      const msgCopy = { ...msg };
-      if ('reasoningContent' in msgCopy) {
-        delete msgCopy.reasoningContent;
-      }
-      return msgCopy;
-    });
+    const messagesWithoutReasoningContent = messageHistoryStore
+      .getSnapshot()
+      .map((msg) => {
+        const msgCopy = { ...msg };
+        if ('reasoningContent' in msgCopy) {
+          delete msgCopy.reasoningContent;
+        }
+        return msgCopy;
+      });
 
     let finalChunk: ChatCompletionChunk | undefined;
 
     const stream = await client.chat.completions.create(
       {
         model: id,
-        messages: apiMessages,
+        messages: messagesWithoutReasoningContent,
         tools: tools,
         stream: true,
       },

--- a/src/core/context/AppContextProvider.tsx
+++ b/src/core/context/AppContextProvider.tsx
@@ -352,9 +352,8 @@ async function doChat(
   const { id, tools } = modelConfig;
   try {
     // Create a copy of messages without reasoningContent for the API call
-    // but don't modify the original messages in the store
+    // but don't modify the original messages in the store which we will render to the UI
     const apiMessages = messageHistoryStore.getSnapshot().map((msg) => {
-      // Create a shallow copy to avoid modifying the original
       const msgCopy = { ...msg };
       if ('reasoningContent' in msgCopy) {
         delete msgCopy.reasoningContent;
@@ -367,7 +366,7 @@ async function doChat(
     const stream = await client.chat.completions.create(
       {
         model: id,
-        messages: apiMessages, // Use the copy without reasoning content
+        messages: apiMessages,
         tools: tools,
         stream: true,
       },


### PR DESCRIPTION
## Summary
Fixes #402 

While we want to strip out reasoning content before posting back to the model, we need to create a copy of messages with the reasoning preserved to render to UI


## Before

https://github.com/user-attachments/assets/21067d70-33e7-476c-983a-99aba01f45d9




## After 

<img width="1305" alt="Screenshot 2025-03-03 at 9 08 38 AM" src="https://github.com/user-attachments/assets/50fcfd6d-9d0a-48e3-9967-8312b27cf597" />
