### PR TITLE
fix: verify both agent & view port to determine mobile

### DIFF
--- a/src/features/blockchain/services/evm/evmBalances.ts
+++ b/src/features/blockchain/services/evm/evmBalances.ts
@@ -23,10 +23,15 @@ export class EvmBalancesQuery implements ChainQuery<EvmBalanceQueryParams> {
   needsWallet = [WalletTypes.METAMASK];
 
   private isMobileDevice(): boolean {
-    // Use regex to detect mobile devices
-    return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-      window.navigator.userAgent,
-    );
+    // use regex to detect mobile devices
+    const isMobileUserAgent =
+      /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+        window.navigator.userAgent,
+      );
+
+    const isMobileViewport = window.innerWidth <= 768;
+
+    return isMobileUserAgent && isMobileViewport;
   }
 
   validate(params: EvmBalanceQueryParams, walletStore: WalletStore): boolean {

--- a/src/features/blockchain/services/evm/evmBalances.ts
+++ b/src/features/blockchain/services/evm/evmBalances.ts
@@ -7,6 +7,7 @@ import {
   chainRegistry,
   EVMChainConfig,
 } from '../../config/chainsRegistry';
+import { validateChain, validateWallet } from '../../utils/wallet';
 
 type EvmBalanceQueryParams = {
   chainName: string;
@@ -22,36 +23,9 @@ export class EvmBalancesQuery implements ChainQuery<EvmBalanceQueryParams> {
   walletMustMatchChainID = false;
   needsWallet = [WalletTypes.METAMASK];
 
-  private isMobileDevice(): boolean {
-    // use regex to detect mobile devices
-    const isMobileUserAgent =
-      /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-        window.navigator.userAgent,
-      );
-
-    const isMobileViewport = window.innerWidth <= 768;
-
-    return isMobileUserAgent && isMobileViewport;
-  }
-
   validate(params: EvmBalanceQueryParams, walletStore: WalletStore): boolean {
-    if (this.isMobileDevice()) {
-      throw new Error('Use a desktop device to connect a wallet');
-    }
-
-    if (!walletStore.getSnapshot().isWalletConnected) {
-      throw new Error('please connect to a compatible wallet');
-    }
-
-    if (Array.isArray(this.needsWallet)) {
-      if (!this.needsWallet.includes(walletStore.getSnapshot().walletType)) {
-        throw new Error('please connect to a compatible wallet');
-      }
-    }
-
-    if (!chainRegistry[this.chainType][params.chainName]) {
-      throw new Error(`unknown chain name ${params.chainName}`);
-    }
+    validateWallet(walletStore, this.needsWallet);
+    validateChain(this.chainType, params.chainName);
 
     return true;
   }

--- a/src/features/blockchain/services/messages/evm/transfer.ts
+++ b/src/features/blockchain/services/messages/evm/transfer.ts
@@ -57,10 +57,15 @@ export class EvmTransferMessage implements ChainMessage<SendToolParams> {
   }
 
   private isMobileDevice(): boolean {
-    // Use regex to detect mobile devices
-    return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-      window.navigator.userAgent,
-    );
+    // use regex to detect mobile devices
+    const isMobileUserAgent =
+      /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+        window.navigator.userAgent,
+      );
+
+    const isMobileViewport = window.innerWidth <= 768;
+
+    return isMobileUserAgent && isMobileViewport;
   }
 
   private async validateBalance(

--- a/src/features/blockchain/services/messages/evm/transfer.ts
+++ b/src/features/blockchain/services/messages/evm/transfer.ts
@@ -13,6 +13,7 @@ import {
   EVMChainConfig,
 } from '../../../config/chainsRegistry';
 import { ConnectWalletPrompt } from '../../../components/ConnectWalletPrompt';
+import { validateChain, validateWallet } from '../../../utils/wallet';
 
 interface SendToolParams {
   chainName: string;
@@ -54,18 +55,6 @@ export class EvmTransferMessage implements ChainMessage<SendToolParams> {
 
   inProgressComponent() {
     return this.hasValidWallet ? InProgressTxDisplay : ConnectWalletPrompt;
-  }
-
-  private isMobileDevice(): boolean {
-    // use regex to detect mobile devices
-    const isMobileUserAgent =
-      /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-        window.navigator.userAgent,
-      );
-
-    const isMobileViewport = window.innerWidth <= 768;
-
-    return isMobileUserAgent && isMobileViewport;
   }
 
   private async validateBalance(
@@ -121,27 +110,13 @@ export class EvmTransferMessage implements ChainMessage<SendToolParams> {
     params: SendToolParams,
     walletStore: WalletStore,
   ): Promise<boolean> {
-    if (this.isMobileDevice()) {
-      throw new Error('Use a desktop device to connect a wallet');
-    }
-
     this.hasValidWallet = false;
-    if (!walletStore.getSnapshot().isWalletConnected) {
-      throw new Error('please connect to a compatible wallet');
-    }
 
-    if (Array.isArray(this.needsWallet)) {
-      if (!this.needsWallet.includes(walletStore.getSnapshot().walletType)) {
-        throw new Error('please connect to a compatible wallet');
-      }
-    }
+    validateWallet(walletStore, this.needsWallet);
+    validateChain(this.chainType, params.chainName);
 
     //  wallet checks have passed
     this.hasValidWallet = true;
-
-    if (!chainRegistry[this.chainType][params.chainName]) {
-      throw new Error(`unknown chain name ${params.chainName}`);
-    }
 
     const { toAddress, amount, denom } = params;
 

--- a/src/features/blockchain/utils/wallet.ts
+++ b/src/features/blockchain/utils/wallet.ts
@@ -1,0 +1,64 @@
+import { WalletStore, WalletTypes } from '../stores/walletStore';
+import { ChainType } from '../types/chain';
+import { chainRegistry } from '../config/chainsRegistry';
+
+/**
+ * Detects if the current device is a mobile device based on user agent and viewport width
+ * @returns boolean - true if the device is mobile, false otherwise
+ */
+export function isMobileDevice(): boolean {
+  //  Use regex to detect mobile
+  const isMobileUserAgent =
+    /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+      window.navigator.userAgent,
+    );
+
+  const isMobileViewport = window.innerWidth <= 768;
+
+  //  But also confirm the viewport (chrome devtools throws a false positive based on agent-alone)
+  return isMobileUserAgent && isMobileViewport;
+}
+
+/**
+ * Validates if the wallet is connected and compatible
+ * @param walletStore The wallet store instance
+ * @param requiredWalletTypes Array of required wallet types
+ * @returns boolean - true if wallet is valid, throws error otherwise
+ */
+export function validateWallet(
+  walletStore: WalletStore,
+  requiredWalletTypes: WalletTypes[] | null,
+): boolean {
+  if (isMobileDevice()) {
+    throw new Error('Use a desktop device to connect a wallet');
+  }
+
+  if (!walletStore.getSnapshot().isWalletConnected) {
+    throw new Error('please connect to a compatible wallet');
+  }
+
+  if (Array.isArray(requiredWalletTypes)) {
+    if (!requiredWalletTypes.includes(walletStore.getSnapshot().walletType)) {
+      throw new Error('please connect to a compatible wallet');
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Validates if a chain name exists in the registry
+ * @param chainType The type of chain (EVM, etc.)
+ * @param chainName The name of the chain to validate
+ * @returns boolean - true if chain is valid, throws error otherwise
+ */
+export function validateChain(
+  chainType: ChainType,
+  chainName: string,
+): boolean {
+  if (!chainRegistry[chainType][chainName]) {
+    throw new Error(`unknown chain name ${chainName}`);
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary

 When validating an evm tool call, we check that the user is not on mobile (and wouldn't be able to use metamask). However, if a user has the chrome dev tools open, they can get false positives based on the agent. Also, if a user resizes their desktop viewport to be narrower, we can also get false positives.
 
 So let's verify both. 



## Before

https://github.com/user-attachments/assets/9a01ca2e-75b1-45b8-bafe-25c1b3d322b6


## After

https://github.com/user-attachments/assets/d8dd3aab-d1ec-4f85-971e-d46913c48ba1

![Screenshot 2025-03-03 at 12 53 18 PM](https://github.com/user-attachments/assets/b03a7d5e-707e-4b15-b8ad-293bce1c8c99)


