### PR TITLE
config: remove deprecated feature flag

### DIFF
--- a/src/core/config/models.ts
+++ b/src/core/config/models.ts
@@ -62,6 +62,4 @@ const defaultModelFromQueryParams = () => {
 
 export const DEFAULT_MODEL_NAME = defaultModelFromQueryParams()
   ? defaultModelFromQueryParams()!
-  : import.meta.env.VITE_FEAT_UPDATED_DESIGN
-    ? 'deepseek-r1'
-    : 'gpt-4o';
+  : 'deepseek-r1';


### PR DESCRIPTION
## Summary
- This feature flag is true in production and we no longer using it to set the default model and just rely on query params.
