### PR TITLE
feat: don't allow uploads of larger than 8MB

### DIFF
--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -708,8 +708,7 @@ describe('chat', () => {
     await paperclipButton.click();
     const fileChooser = await fileChooserPromise;
 
-    const eightMBPlus = 7 * 1024 * 1024 + 1024; // 7MB
-    const buffer = Buffer.alloc(eightMBPlus, 'x');
+    const buffer = Buffer.alloc(7 * 1024 * 1024 + 1024, 'x');
 
     const fileWithinLimit = {
       name: 'withinLimit-image.png',
@@ -812,9 +811,8 @@ describe('chat', () => {
     await paperclipButton.click();
     const fileChooser = await fileChooserPromise;
 
-    // Create a buffer slightly larger than 8MB
-    const eightMBPlus = 8 * 1024 * 1024 + 1024; // 8MB + 1KB
-    const largeBuffer = Buffer.alloc(eightMBPlus, 'x');
+    //  9MB
+    const largeBuffer = Buffer.alloc(9 * 1024 * 1024 + 1024, 'x');
 
     const oversizedFile = {
       name: 'oversized-image.png',
@@ -824,7 +822,6 @@ describe('chat', () => {
 
     await fileChooser.setFiles([oversizedFile]);
 
-    // Check for the error message
     const errorMessage = page.getByText(
       'File too large! Maximum file size is 8MB.',
     );

--- a/src/core/components/ChatInput.tsx
+++ b/src/core/components/ChatInput.tsx
@@ -22,6 +22,8 @@ const SUPPORTED_FILE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
 const MAX_FILE_UPLOADS = 4;
 
+const MAX_FILE_BYTES = 8 * 1024 * 1024;
+
 interface ChatInputProps {
   setShouldAutoScroll: (s: boolean) => void;
 }
@@ -169,6 +171,21 @@ const ChatInput = ({ setShouldAutoScroll }: ChatInputProps) => {
   const processFile = useCallback(
     async (file: File) => {
       if (!hasAvailableUploads()) {
+        return;
+      }
+
+      if (file.size > MAX_FILE_BYTES) {
+        setUploadingState({
+          isActive: true,
+          isSupportedFile: false,
+          errorMessage: 'File too large! Maximum file size is 8MB.',
+        });
+
+        // Present the error for a short time, then reset
+        setTimeout(() => {
+          resetUploadState();
+        }, 2000);
+
         return;
       }
 
@@ -329,6 +346,19 @@ const ChatInput = ({ setShouldAutoScroll }: ChatInputProps) => {
           setTimeout(() => {
             resetUploadState();
           }, 2000);
+        } else if (
+          Array.from(files).filter((file) => file.size > MAX_FILE_BYTES)
+        ) {
+          setUploadingState({
+            isActive: true,
+            isSupportedFile: false,
+            errorMessage: 'File too large! Maximum file size is 8MB.',
+          });
+
+          setTimeout(() => {
+            resetUploadState();
+          }, 2000);
+          return;
         } else {
           Array.from(files).forEach((file) => {
             processFile(file);


### PR DESCRIPTION
## Summary
- inform user if they attempt to upload a file over the 8MB limit via click or drag & drop
- if a user attempts to upload multiple files, it will filter out those too large and include those within limits
- verify through e2e tests
