### PR TITLE
feat: clear uploaded images on model switch and conversation switch

### DIFF
--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -894,4 +894,42 @@ describe('chat', () => {
       expect(count).toEqual(1);
     }
   });
+  test('image previews are cleared on model switch', async ({ page }) => {
+    test.setTimeout(30 * 1000);
+
+    const chat = new Chat(page);
+    await chat.goto();
+
+    const paperclipButton = page.getByRole('button', {
+      name: 'Attach file icon',
+    });
+
+    const imagePath = join(process.cwd(), 'e2e/images/orosLogo.png');
+
+    const buffer = fs.readFileSync(imagePath);
+
+    const fileChooserPromise = page.waitForEvent('filechooser');
+    await paperclipButton.click();
+    const fileChooser = await fileChooserPromise;
+
+    const fileWithinLimit = {
+      name: 'orosLogo.png',
+      mimeType: 'image/png',
+      buffer,
+    };
+
+    await fileChooser.setFiles([fileWithinLimit]);
+
+    const imagePreviewContainer = page.locator('.imagePreviewContainer');
+
+    if (await imagePreviewContainer.isVisible()) {
+      const imageCards = page.locator('.imageCard');
+      const count = await imageCards.count();
+      expect(count).toEqual(1);
+    }
+
+    await chat.switchToBlockchainModel();
+
+    expect(await imagePreviewContainer.isVisible()).toBe(false);
+  });
 });

--- a/src/core/components/ChatInput.tsx
+++ b/src/core/components/ChatInput.tsx
@@ -70,6 +70,19 @@ const ChatInput = ({ setShouldAutoScroll }: ChatInputProps) => {
 
   const [imageIDs, setImageIDs] = useState<string[]>([]);
 
+  const prevModelIdRef = useRef(modelConfig.id);
+  const prevConversationRef = useRef(conversationID);
+
+  useEffect(() => {
+    if (
+      prevModelIdRef.current !== modelConfig.id ||
+      prevConversationRef.current !== conversationID
+    ) {
+      setImageIDs([]);
+      prevModelIdRef.current = modelConfig.id;
+      prevConversationRef.current = conversationID;
+    }
+  }, [conversationID, modelConfig.id]);
   const handleInputChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
       /**

--- a/src/core/components/Conversation/Conversation.tsx
+++ b/src/core/components/Conversation/Conversation.tsx
@@ -29,8 +29,6 @@ const ConversationComponent = ({ onRendered }: ConversationProps) => {
   return (
     <div className={styles.conversationContainer} data-testid="conversation">
       {messages.map((message, index) => {
-        // console.log(index);
-        // console.log(index - 1);
         if (message.role === 'user') {
           let hasImage = false;
           let imageIDs: string[] = [];


### PR DESCRIPTION
## Summary
Image upload previews are reset when
- the user changes model
- the user changes conversation (even if they select an older conversation on reasoning model - state is fully reset)

## Demo 


https://github.com/user-attachments/assets/98336a44-d71f-4fbc-a981-4b0585615643

