### PR TITLE
fix: Use a wrapper to center icons in line with each other

### DIFF
--- a/src/core/components/ChatInput.module.css
+++ b/src/core/components/ChatInput.module.css
@@ -56,7 +56,13 @@
 .buttonContainer {
   flex-shrink: 0;
   display: flex;
+  align-items: flex-end;
+}
+
+.buttonWrapper {
+  display: flex;
   align-items: center;
+  gap: var(--spacing-xs);
 }
 
 .sendChatButton {
@@ -149,11 +155,6 @@
 
 .removeButton:hover {
   background-color: var(--colors-bgSecondary);
-}
-
-
-.attachIcon {
-  margin-right: var(--spacing-xs);
 }
 
 .attachIcon:hover {

--- a/src/core/components/ChatInput.tsx
+++ b/src/core/components/ChatInput.tsx
@@ -482,49 +482,51 @@ const ChatInput = ({ setShouldAutoScroll }: ChatInputProps) => {
           )}
         </div>
         <div className={styles.buttonContainer}>
-          {SUPPORT_FILE_UPLOAD && modelSupportsUpload && (
-            <>
-              <div className={styles.uploadInputFieldContainer}>
-                <input
-                  accept={SUPPORTED_FILE_TYPES.join(', ')}
-                  ref={uploadRef}
-                  type="file"
-                  className={styles.uploadInputField}
-                  onChange={handleUpload}
-                  multiple // Allow multiple file selection
+          <div className={styles.buttonWrapper}>
+            {SUPPORT_FILE_UPLOAD && modelSupportsUpload && (
+              <>
+                <div className={styles.uploadInputFieldContainer}>
+                  <input
+                    accept={SUPPORTED_FILE_TYPES.join(', ')}
+                    ref={uploadRef}
+                    type="file"
+                    className={styles.uploadInputField}
+                    onChange={handleUpload}
+                    multiple // Allow multiple file selection
+                    disabled={imageIDs.length >= MAX_FILE_UPLOADS}
+                  />
+                </div>
+
+                <ButtonIcon
+                  icon={Paperclip}
+                  size={16}
+                  aria-label="Attach file icon"
+                  className={`${styles.attachIcon} ${imageIDs.length >= MAX_FILE_UPLOADS ? styles.disabled : ''}`}
+                  onClick={() =>
+                    imageIDs.length < MAX_FILE_UPLOADS &&
+                    uploadRef.current?.click()
+                  }
+                  tooltip={{
+                    text: 'Attach file - max 4, 8MB each',
+                    position: 'bottom',
+                    backgroundColor: colors.bgPrimary,
+                  }}
                   disabled={imageIDs.length >= MAX_FILE_UPLOADS}
                 />
-              </div>
-
-              <ButtonIcon
-                icon={Paperclip}
-                size={16}
-                aria-label="Attach file icon"
-                className={`${styles.attachIcon} ${imageIDs.length >= MAX_FILE_UPLOADS ? styles.disabled : ''}`}
-                onClick={() =>
-                  imageIDs.length < MAX_FILE_UPLOADS &&
-                  uploadRef.current?.click()
-                }
-                tooltip={{
-                  text: 'Attach file - max 4, 8MB each',
-                  position: 'bottom',
-                  backgroundColor: colors.bgPrimary,
-                }}
-                disabled={imageIDs.length >= MAX_FILE_UPLOADS}
-              />
-            </>
-          )}
-          <button
-            data-testid="chat-view-button"
-            ref={buttonRef}
-            className={styles.sendChatButton}
-            type="submit"
-            onClick={handleButtonClick}
-            aria-label="Send Chat"
-            disabled={disableSubmit}
-          >
-            {isRequesting ? <CancelChatIcon /> : <SendChatIcon />}
-          </button>
+              </>
+            )}
+            <button
+              data-testid="chat-view-button"
+              ref={buttonRef}
+              className={styles.sendChatButton}
+              type="submit"
+              onClick={handleButtonClick}
+              aria-label="Send Chat"
+              disabled={disableSubmit}
+            >
+              {isRequesting ? <CancelChatIcon /> : <SendChatIcon />}
+            </button>
+          </div>
         </div>
       </div>
     </>


### PR DESCRIPTION
This keeps the flex-end controls, but uses a wrapping container around only the button icons to keep them centered in a line with each other.

In addition, removes the margin in favor of gap.  When using flex to align items, gap is preferred to set spacing between elements.

## Summary

## Demo

Before:
![Screenshot 2025-03-06 at 4 58 58 PM](https://github.com/user-attachments/assets/06040d07-d981-4142-8f78-fac24c7fbc26)

After:
![Screenshot 2025-03-06 at 4 59 19 PM](https://github.com/user-attachments/assets/467657ad-81ca-419e-b224-65bec400b156)


## Open Questions

## Follow-on tasks
