### PR TITLE
fix: reset thinking store on cancel click

### DIFF
--- a/src/core/context/AppContextProvider.tsx
+++ b/src/core/context/AppContextProvider.tsx
@@ -300,8 +300,9 @@ export const AppContextProvider = (props: {
       controllerRef.current.abort();
       controllerRef.current = null;
       toolCallStreamStore.clear();
+      thinkingStore.setText('');
     }
-  }, [toolCallStreamStore]);
+  }, [thinkingStore, toolCallStreamStore]);
 
   return (
     <AppContext.Provider


### PR DESCRIPTION
## Summary
- addresses #438 
- reset the thinking store when the user cancels the stream

## Demo 

## Open Questions

## Follow-on tasks
