### PR TITLE
feat: loading skeleton for images in chat

### DIFF
--- a/src/core/components/Conversation/Conversation.module.css
+++ b/src/core/components/Conversation/Conversation.module.css
@@ -86,10 +86,7 @@ li {
 }
 
 .chatImage {
-  margin-top: var(--spacing-xs);
-  margin-left: auto;
-  margin-bottom: var(--spacing-xs);
-  margin-top: var(--spacing-xs);
+  margin: var(--spacing-xs) 0 var(--spacing-xs) auto;
   width: 256px;
   height: 256px;
   position: relative;

--- a/src/core/components/Conversation/Conversation.module.css
+++ b/src/core/components/Conversation/Conversation.module.css
@@ -2,7 +2,6 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-
   padding: var(--spacing-sm) var(--spacing-sm) var(--spacing-md);
 }
 
@@ -84,4 +83,37 @@ li {
   top: 16px;
   right: 16px;
   z-index: 100;
+}
+
+.chatImage {
+  margin-top: var(--spacing-xs);
+  margin-left: auto;
+  margin-bottom: var(--spacing-xs);
+  margin-top: var(--spacing-xs);
+  width: 256px;
+  height: 256px;
+  position: relative;
+}
+
+.imageSkeleton {
+  width: 100%;
+  height: 100%;
+  background: var(--colors-bgSecondary);
+  border-radius: var(--borderRadius-md);
+  position: absolute;
+  top: 0;
+  left: 0;
+  animation: pulse 1.5s infinite ease-in-out;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 0.8;
+  }
+  100% {
+    opacity: 0.6;
+  }
 }

--- a/src/core/components/Conversation/Conversation.tsx
+++ b/src/core/components/Conversation/Conversation.tsx
@@ -1,5 +1,5 @@
 import styles from './Conversation.module.css';
-import { Fragment, memo } from 'react';
+import { Fragment, memo, useState } from 'react';
 import { useSyncExternalStore } from 'react';
 import { ToolMessageContainer } from './ToolMessageContainer';
 import { StreamingMessage } from './StreamingMessage';
@@ -25,6 +25,14 @@ const ConversationComponent = ({ onRendered }: ConversationProps) => {
   );
 
   const { messages } = useMessageHistory();
+  const [loadedImages, setLoadedImages] = useState<Record<string, boolean>>({});
+
+  const handleImageLoad = (imageID: string) => {
+    setLoadedImages((prev) => ({
+      ...prev,
+      [imageID]: true,
+    }));
+  };
 
   return (
     <div className={styles.conversationContainer} data-testid="conversation">
@@ -71,19 +79,24 @@ const ConversationComponent = ({ onRendered }: ConversationProps) => {
             <Fragment key={index}>
               {hasImage
                 ? imageIDs.map((imageID, i) => (
-                    <div
-                      key={imageID}
-                      style={{
-                        marginLeft: 'auto',
-                        marginBottom: '4px',
-                        marginTop: '4px',
-                      }}
-                    >
+                    <div key={imageID} className={styles.chatImage}>
+                      {!loadedImages[imageID] && (
+                        <div className={styles.imageSkeleton}></div>
+                      )}
                       <IdbImage
                         width="256px"
                         height="256px"
                         id={imageID}
                         aria-label={`User uploaded image ${i + 1}`}
+                        onLoad={() => handleImageLoad(imageID)}
+                        style={{
+                          visibility: loadedImages[imageID]
+                            ? 'visible'
+                            : 'hidden',
+                          position: 'absolute',
+                          top: 0,
+                          left: 0,
+                        }}
                       />
                     </div>
                   ))

--- a/src/core/components/Conversation/Conversation.tsx
+++ b/src/core/components/Conversation/Conversation.tsx
@@ -89,14 +89,6 @@ const ConversationComponent = ({ onRendered }: ConversationProps) => {
                         id={imageID}
                         aria-label={`User uploaded image ${i + 1}`}
                         onLoad={() => handleImageLoad(imageID)}
-                        style={{
-                          visibility: loadedImages[imageID]
-                            ? 'visible'
-                            : 'hidden',
-                          position: 'absolute',
-                          top: 0,
-                          left: 0,
-                        }}
                       />
                     </div>
                   ))


### PR DESCRIPTION
## Summary
- addresses #447 
- add loading skeleton for images
- this removes flash caused by images loading after text

## Demo 

https://github.com/user-attachments/assets/0aa66c02-256a-4fe5-8c79-482fa8ac0e95


![Screenshot 2025-03-07 at 1 05 26 PM](https://github.com/user-attachments/assets/f07afdac-35d0-4b1b-987a-014a5d33da30)

![Screenshot 2025-03-07 at 1 05 56 PM](https://github.com/user-attachments/assets/28c3f2a3-589e-4cb8-aa35-b620f1dbef84)

