### PR TITLE
refactor: supported file types to model config

### DIFF
--- a/src/core/components/ChatInput.tsx
+++ b/src/core/components/ChatInput.tsx
@@ -12,11 +12,10 @@ import { IdbImage } from './IdbImage';
 import ButtonIcon from './ButtonIcon';
 import { useTheme } from '../../shared/theme/useTheme';
 import { ChatCompletionContentPart } from 'openai/resources/index';
-import { useHandleDragAndDrop } from '../hooks/useHandleDragAndDrop';
+import { useDragAndDrop } from '../hooks/useDragAndDrop';
+import { isSupportedFileType } from '../types/models';
 
 const DEFAULT_HEIGHT = '30px';
-
-const SUPPORTED_FILE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
 const MAX_FILE_UPLOADS = 4;
 
@@ -67,6 +66,8 @@ const ChatInput = ({ setShouldAutoScroll }: ChatInputProps) => {
     handleCancel,
     conversationID,
   } = useAppContext();
+
+  const { supportedFileTypes } = modelConfig;
 
   const buttonRef = useRef<HTMLButtonElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -206,7 +207,7 @@ const ChatInput = ({ setShouldAutoScroll }: ChatInputProps) => {
         return;
       }
 
-      if (!SUPPORTED_FILE_TYPES.includes(file.type)) {
+      if (!isSupportedFileType(file.type)) {
         setUploadingState({
           isActive: true,
           isSupportedFile: false,
@@ -289,15 +290,14 @@ const ChatInput = ({ setShouldAutoScroll }: ChatInputProps) => {
     ? currentConversation.tokensRemaining
     : modelConfig.contextLength;
 
-  const modelSupportsUpload = modelConfig.supportedFileTypes.length > 0;
+  const modelSupportsUpload = supportedFileTypes.length > 0;
 
-  useHandleDragAndDrop({
-    modelSupportsUpload,
+  useDragAndDrop({
     hasAvailableUploads,
     processFile,
     resetUploadState,
     imageIDs,
-    SUPPORTED_FILE_TYPES,
+    supportedFileTypes,
     MAX_FILE_UPLOADS,
     MAX_FILE_BYTES,
     setUploadingState,
@@ -387,7 +387,7 @@ const ChatInput = ({ setShouldAutoScroll }: ChatInputProps) => {
               <>
                 <div className={styles.uploadInputFieldContainer}>
                   <input
-                    accept={SUPPORTED_FILE_TYPES.join(', ')}
+                    accept={supportedFileTypes.join(', ')}
                     ref={uploadRef}
                     type="file"
                     className={styles.uploadInputField}

--- a/src/core/hooks/useDragAndDrop.test.ts
+++ b/src/core/hooks/useDragAndDrop.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import { useDragAndDrop } from './useDragAndDrop';
 import { renderHook } from '@testing-library/react';
+import { SupportedFileType } from '../types/models';
 
 const createFileList = (files: File[]): FileList => {
   return {
@@ -21,7 +22,11 @@ describe('useHandleDragAndDrop', () => {
     processFile: mockProcessFile,
     resetUploadState: mockResetUploadState,
     imageIDs: [],
-    supportedFileTypes: ['image/jpeg', 'image/png', 'image/webp'],
+    supportedFileTypes: [
+      'image/jpeg',
+      'image/png',
+      'image/webp',
+    ] as Array<SupportedFileType>,
     MAX_FILE_UPLOADS: 4,
     MAX_FILE_BYTES: 8 * 1024 * 1024, // 8MB
     setUploadingState: mockSetUploadingState,

--- a/src/core/hooks/useDragAndDrop.test.ts
+++ b/src/core/hooks/useDragAndDrop.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
-import { useHandleDragAndDrop } from './useHandleDragAndDrop';
+import { useDragAndDrop } from './useDragAndDrop';
 import { renderHook } from '@testing-library/react';
 
 const createFileList = (files: File[]): FileList => {
@@ -17,12 +17,11 @@ describe('useHandleDragAndDrop', () => {
   const mockResetUploadState = vi.fn();
 
   const defaultParams = {
-    modelSupportsUpload: true,
     hasAvailableUploads: mockHasAvailableUploads,
     processFile: mockProcessFile,
     resetUploadState: mockResetUploadState,
     imageIDs: [],
-    SUPPORTED_FILE_TYPES: ['image/jpeg', 'image/png', 'image/webp'],
+    supportedFileTypes: ['image/jpeg', 'image/png', 'image/webp'],
     MAX_FILE_UPLOADS: 4,
     MAX_FILE_BYTES: 8 * 1024 * 1024, // 8MB
     setUploadingState: mockSetUploadingState,
@@ -64,7 +63,7 @@ describe('useHandleDragAndDrop', () => {
   });
 
   it('should register event listeners when modelSupportsUpload is true', () => {
-    renderHook(() => useHandleDragAndDrop(defaultParams));
+    renderHook(() => useDragAndDrop(defaultParams));
 
     const registeredEvents = (document.addEventListener as Mock).mock.calls.map(
       (call) => call[0],
@@ -76,11 +75,11 @@ describe('useHandleDragAndDrop', () => {
     expect(registeredEvents).toContain('drop');
   });
 
-  it('should not register event listeners when modelSupportsUpload is false', () => {
+  it('should not register event listeners when model has no supported file types', () => {
     renderHook(() =>
-      useHandleDragAndDrop({
+      useDragAndDrop({
         ...defaultParams,
-        modelSupportsUpload: false,
+        supportedFileTypes: [],
       }),
     );
 
@@ -88,7 +87,7 @@ describe('useHandleDragAndDrop', () => {
   });
 
   it('should unregister event listeners on unmount', () => {
-    const { unmount } = renderHook(() => useHandleDragAndDrop(defaultParams));
+    const { unmount } = renderHook(() => useDragAndDrop(defaultParams));
 
     unmount();
 
@@ -133,7 +132,7 @@ describe('useHandleDragAndDrop', () => {
     };
 
     it('should handle dragenter event with valid file type', () => {
-      renderHook(() => useHandleDragAndDrop(defaultParams));
+      renderHook(() => useDragAndDrop(defaultParams));
 
       const mockDataTransfer = {
         items: [
@@ -159,7 +158,7 @@ describe('useHandleDragAndDrop', () => {
     });
 
     it('should handle dragenter event with invalid file type', () => {
-      renderHook(() => useHandleDragAndDrop(defaultParams));
+      renderHook(() => useDragAndDrop(defaultParams));
 
       const mockDataTransfer = {
         items: [
@@ -187,7 +186,7 @@ describe('useHandleDragAndDrop', () => {
     it('should not proceed with dragenter when hasAvailableUploads returns false', () => {
       mockHasAvailableUploads.mockReturnValueOnce(false);
 
-      renderHook(() => useHandleDragAndDrop(defaultParams));
+      renderHook(() => useDragAndDrop(defaultParams));
 
       const mockDataTransfer = {
         items: [
@@ -209,7 +208,7 @@ describe('useHandleDragAndDrop', () => {
     });
 
     it('should handle dragover event', () => {
-      renderHook(() => useHandleDragAndDrop(defaultParams));
+      renderHook(() => useDragAndDrop(defaultParams));
 
       const mockEvent = triggerEvent('dragover');
 
@@ -219,7 +218,7 @@ describe('useHandleDragAndDrop', () => {
     });
 
     it('should handle dragleave event when leaving document', () => {
-      renderHook(() => useHandleDragAndDrop(defaultParams));
+      renderHook(() => useDragAndDrop(defaultParams));
 
       const mockEvent = triggerEvent('dragleave', { relatedTarget: null });
 
@@ -231,7 +230,7 @@ describe('useHandleDragAndDrop', () => {
 
   describe('drop event handler', () => {
     it('should process valid dropped files', () => {
-      renderHook(() => useHandleDragAndDrop(defaultParams));
+      renderHook(() => useDragAndDrop(defaultParams));
 
       const files = [
         new File(['content'], 'image1.jpg', { type: 'image/jpeg' }),
@@ -272,7 +271,7 @@ describe('useHandleDragAndDrop', () => {
 
     it('should show error when drop exceeds MAX_FILE_UPLOADS', () => {
       renderHook(() =>
-        useHandleDragAndDrop({
+        useDragAndDrop({
           ...defaultParams,
           imageIDs: ['existing1', 'existing2', 'existing3'],
           MAX_FILE_UPLOADS: 4,
@@ -314,7 +313,7 @@ describe('useHandleDragAndDrop', () => {
 
     it('should show error when drop contains files larger than MAX_FILE_BYTES', () => {
       renderHook(() =>
-        useHandleDragAndDrop({
+        useDragAndDrop({
           ...defaultParams,
           MAX_FILE_BYTES: 1000, // Small limit for testing
         }),

--- a/src/core/hooks/useDragAndDrop.ts
+++ b/src/core/hooks/useDragAndDrop.ts
@@ -2,12 +2,11 @@ import { useEffect, useCallback, Dispatch, SetStateAction } from 'react';
 import { UploadingState } from '../components/ChatInput';
 
 interface UseHandleDragAndDropParams {
-  modelSupportsUpload: boolean;
   hasAvailableUploads: () => boolean;
   processFile: (file: File) => Promise<void>;
   resetUploadState: () => void;
   imageIDs: string[];
-  SUPPORTED_FILE_TYPES: string[];
+  supportedFileTypes: string[];
   MAX_FILE_UPLOADS: number;
   MAX_FILE_BYTES: number;
   setUploadingState: Dispatch<SetStateAction<UploadingState>>;
@@ -19,25 +18,23 @@ interface UseHandleDragAndDropParams {
  * state updates, and file processing.
  *
  * @param params - Configuration parameters for the drag and drop behavior
- * @param params.modelSupportsUpload - Flag indicating if the current model supports file uploads
  * @param params.hasAvailableUploads - Function that checks if more uploads are allowed
  * @param params.processFile - Function that handles processing a valid file
  * @param params.resetUploadState - Function that resets the uploading state
  * @param params.imageIDs - Array of currently uploaded image IDs
- * @param params.SUPPORTED_FILE_TYPES - Array of accepted MIME types
+ * @param params.supportedFileTypes - Array of accepted MIME types
  * @param params.MAX_FILE_UPLOADS - Maximum number of files allowed
  * @param params.MAX_FILE_BYTES - Maximum file size in bytes
  * @param params.setUploadingState - State setter for the uploading state
  *
  * @returns void - This hook doesn't return any values but sets up event listeners
  */
-export const useHandleDragAndDrop = ({
-  modelSupportsUpload,
+export const useDragAndDrop = ({
   hasAvailableUploads,
   processFile,
   resetUploadState,
   imageIDs,
-  SUPPORTED_FILE_TYPES,
+  supportedFileTypes,
   MAX_FILE_UPLOADS,
   MAX_FILE_BYTES,
   setUploadingState,
@@ -57,7 +54,7 @@ export const useHandleDragAndDrop = ({
 
         if (item.kind === 'file') {
           const fileType = item.type;
-          const isValid = SUPPORTED_FILE_TYPES.includes(fileType);
+          const isValid = supportedFileTypes.includes(fileType);
           setUploadingState({
             isActive: true,
             isSupportedFile: isValid,
@@ -68,7 +65,7 @@ export const useHandleDragAndDrop = ({
         }
       }
     },
-    [hasAvailableUploads, SUPPORTED_FILE_TYPES, setUploadingState],
+    [hasAvailableUploads, supportedFileTypes, setUploadingState],
   );
 
   const handleDragOver = useCallback(
@@ -114,7 +111,7 @@ export const useHandleDragAndDrop = ({
         const totalFilesAfterDrop = imageIDs.length + files.length;
 
         const hasUnsupportedType = Array.from(files).some(
-          (file) => !SUPPORTED_FILE_TYPES.includes(file.type),
+          (file) => !supportedFileTypes.includes(file.type),
         );
 
         if (hasUnsupportedType) {
@@ -164,7 +161,7 @@ export const useHandleDragAndDrop = ({
       imageIDs.length,
       MAX_FILE_BYTES,
       MAX_FILE_UPLOADS,
-      SUPPORTED_FILE_TYPES,
+      supportedFileTypes,
       processFile,
       resetUploadState,
       setUploadingState,
@@ -172,7 +169,7 @@ export const useHandleDragAndDrop = ({
   );
 
   useEffect(() => {
-    if (!modelSupportsUpload) {
+    if (!supportedFileTypes.length) {
       return;
     }
 
@@ -190,10 +187,10 @@ export const useHandleDragAndDrop = ({
       document.removeEventListener('drop', handleDrop);
     };
   }, [
-    modelSupportsUpload,
     handleDragEnter,
     handleDragOver,
     handleDragLeave,
     handleDrop,
+    supportedFileTypes.length,
   ]);
 };

--- a/src/core/hooks/useDragAndDrop.ts
+++ b/src/core/hooks/useDragAndDrop.ts
@@ -1,12 +1,13 @@
 import { useEffect, useCallback, Dispatch, SetStateAction } from 'react';
 import { UploadingState } from '../components/ChatInput';
+import { isSupportedFileType, SupportedFileType } from '../types/models';
 
 interface UseHandleDragAndDropParams {
   hasAvailableUploads: () => boolean;
   processFile: (file: File) => Promise<void>;
   resetUploadState: () => void;
   imageIDs: string[];
-  supportedFileTypes: string[];
+  supportedFileTypes: Array<SupportedFileType>;
   MAX_FILE_UPLOADS: number;
   MAX_FILE_BYTES: number;
   setUploadingState: Dispatch<SetStateAction<UploadingState>>;
@@ -54,7 +55,7 @@ export const useDragAndDrop = ({
 
         if (item.kind === 'file') {
           const fileType = item.type;
-          const isValid = supportedFileTypes.includes(fileType);
+          const isValid = isSupportedFileType(fileType);
           setUploadingState({
             isActive: true,
             isSupportedFile: isValid,
@@ -111,7 +112,7 @@ export const useDragAndDrop = ({
         const totalFilesAfterDrop = imageIDs.length + files.length;
 
         const hasUnsupportedType = Array.from(files).some(
-          (file) => !supportedFileTypes.includes(file.type),
+          (file) => !isSupportedFileType(file.type),
         );
 
         if (hasUnsupportedType) {

--- a/src/core/types/models.ts
+++ b/src/core/types/models.ts
@@ -69,4 +69,14 @@ export interface ContextMetrics {
   tokensRemaining: number;
 }
 
-type SupportedFileType = 'image/jpeg' | 'image/png' | 'image/webp';
+export const SUPPORTED_FILE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+] as const;
+
+export type SupportedFileType = (typeof SUPPORTED_FILE_TYPES)[number];
+
+export function isSupportedFileType(type: string): type is SupportedFileType {
+  return SUPPORTED_FILE_TYPES.includes(type as SupportedFileType);
+}

--- a/src/core/utils/isInIframe.ts
+++ b/src/core/utils/isInIframe.ts
@@ -1,3 +1,0 @@
-export const isInIframe = () => {
-  return window !== window.parent;
-};


### PR DESCRIPTION
## Summary
- implements the model config approach for supported file types set up in #430 
- removes deprecated/unused `isInIframe` helper

## Demo 

## Open Questions

## Follow-on tasks
