### PR TITLE
fix: ensure that the initial system prompt is set

### DIFF
--- a/src/core/context/AppContextProvider.tsx
+++ b/src/core/context/AppContextProvider.tsx
@@ -18,6 +18,7 @@ import { SupportedModels, ModelConfig } from '../types/models';
 import { ActiveConversation, ConversationHistory } from './types';
 import { getToken } from '../../core/utils/token/token';
 import OpenAI from 'openai';
+import { v4 as uuidv4 } from 'uuid';
 import { doChat, syncWithLocalStorage, newConversation } from './utils';
 import type { ChatCompletionContentPart } from 'openai/resources/index';
 
@@ -45,7 +46,16 @@ export const AppContextProvider = (props: {
   );
 
   const [conversation, setConversation] = useState<ActiveConversation>(() => {
-    const newConv = newConversation();
+    const newConv = {
+      conversationID: uuidv4(),
+      messageHistoryStore: props.messageHistoryStore,
+      toolCallStreamStore: props.toolCallStreamStore,
+      thinkingStore: props.thinkingStore,
+      progressStore: props.progressStore,
+      messageStore: props.messageStore,
+      errorStore: new TextStreamStore(),
+      isRequesting: false,
+    };
 
     const messages = newConv.messageHistoryStore.getSnapshot();
     if (messages.length === 0) {

--- a/src/core/context/AppContextProvider.tsx
+++ b/src/core/context/AppContextProvider.tsx
@@ -18,7 +18,6 @@ import { SupportedModels, ModelConfig } from '../types/models';
 import { ActiveConversation, ConversationHistory } from './types';
 import { getToken } from '../../core/utils/token/token';
 import OpenAI from 'openai';
-import { v4 as uuidv4 } from 'uuid';
 import { doChat, syncWithLocalStorage, newConversation } from './utils';
 import type { ChatCompletionContentPart } from 'openai/resources/index';
 

--- a/src/core/context/AppContextProvider.tsx
+++ b/src/core/context/AppContextProvider.tsx
@@ -154,13 +154,6 @@ export const AppContextProvider = (props: {
     [],
   );
 
-  // // //  When the in
-  // useEffect(() => {
-  //   if (isReady && messageHistoryStore) {
-  //     ensureCorrectSystemPrompt(messageHistoryStore, modelConfig);
-  //   }
-  // }, [isReady, messageHistoryStore, modelConfig, ensureCorrectSystemPrompt]);
-
   const handleModelChange = useCallback(
     (modelName: SupportedModels) => {
       const newConfig = getModelConfig(modelName);
@@ -219,7 +212,7 @@ export const AppContextProvider = (props: {
     }
 
     setIsReady(true);
-  }, [ensureCorrectSystemPrompt, messageHistoryStore, modelConfig]);
+  }, []);
 
   // abort controller for cancelling openai request
   const controllerRef = useRef<AbortController | null>(null);


### PR DESCRIPTION
## Summary
- In this bug fix #401 , we inadvertently removed setting the initial system prompt. Nothing triggered `ensureCorrectSystemPrompt` to run on initial load, only on model switch

## Before

https://github.com/user-attachments/assets/99789468-160e-435a-b5fc-dbf944a24414



## After

https://github.com/user-attachments/assets/88daf86d-53c2-4ef6-9497-0185244bcc98



