### PR TITLE
fix(api): Allow any header for preflight check

### DIFF
--- a/api/cmd/api/cors_test.go
+++ b/api/cmd/api/cors_test.go
@@ -56,7 +56,7 @@ func TestCors(t *testing.T) {
 			wantResponseHeaders: map[string]string{
 				"Access-Control-Allow-Origin":  "*",
 				"Access-Control-Allow-Methods": "POST, OPTIONS",
-				"Access-Control-Allow-Headers": "Authorization, Content-Type, x-stainless-os, x-stainless-runtime-version, x-stainless-package-version, x-stainless-runtime, x-stainless-arch, x-stainless-retry-count, x-stainless-lang, user-agent",
+				"Access-Control-Allow-Headers": "*",
 				"Access-Control-Max-Age":       "3600",
 			},
 		},
@@ -88,7 +88,7 @@ func TestCors(t *testing.T) {
 			wantResponseHeaders: map[string]string{
 				"Access-Control-Allow-Origin":  "*",
 				"Access-Control-Allow-Methods": "POST, OPTIONS",
-				"Access-Control-Allow-Headers": "Authorization, Content-Type, x-stainless-os, x-stainless-runtime-version, x-stainless-package-version, x-stainless-runtime, x-stainless-arch, x-stainless-retry-count, x-stainless-lang, user-agent",
+				"Access-Control-Allow-Headers": "*",
 				"Access-Control-Max-Age":       "3600",
 			},
 		},

--- a/api/internal/middleware/preflight.go
+++ b/api/internal/middleware/preflight.go
@@ -9,7 +9,7 @@ func PreflightMiddleware(next http.Handler) http.Handler {
 		if r.Method == http.MethodOptions {
 			w.Header().Set("Access-Control-Allow-Origin", "*")
 			w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, x-stainless-os, x-stainless-runtime-version, x-stainless-package-version, x-stainless-runtime, x-stainless-arch, x-stainless-retry-count, x-stainless-lang, user-agent")
+			w.Header().Set("Access-Control-Allow-Headers", "*")
 			w.Header().Set("Access-Control-Max-Age", "3600")
 			w.WriteHeader(http.StatusOK)
 			return


### PR DESCRIPTION
## Summary
- New `x-stainless-timeout` header causes CORS policy to block requests
- Set `Access-Control-Allow-Headers` to wildcard value