### PR TITLE
refactor: extract upload error

### DIFF
--- a/src/core/components/ChatInput.tsx
+++ b/src/core/components/ChatInput.tsx
@@ -344,6 +344,7 @@ const ChatInput = ({ setShouldAutoScroll }: ChatInputProps) => {
     modelSupportsUpload,
     resetUploadState,
     maximumFileBytes,
+    setUploadError,
   ]);
 
   const [, setHoverImageId] = useState<string | null>(null);

--- a/src/core/components/ChatInput.tsx
+++ b/src/core/components/ChatInput.tsx
@@ -325,16 +325,7 @@ const ChatInput = ({ setShouldAutoScroll }: ChatInputProps) => {
           const file = item.getAsFile();
           if (file) {
             if (file.size > maximumFileBytes) {
-              setUploadingState({
-                isActive: true,
-                isSupportedFile: false,
-                errorMessage: 'File too large! Maximum file size is 8MB.',
-              });
-
-              setTimeout(() => {
-                resetUploadState();
-              }, 2000);
-
+              setUploadError('File too large! Maximum file size is 8MB.');
               return;
             }
             processUploadedFile(file);

--- a/src/core/components/ChatInput.tsx
+++ b/src/core/components/ChatInput.tsx
@@ -19,6 +19,7 @@ import { useDragAndDrop } from '../hooks/useDragAndDrop';
 import { isSupportedFileType } from '../types/models';
 import useProcessUploadedFile from '../hooks/useProcessUploadedFile';
 import { useAvailableUploads } from '../hooks/useAvailableUploads';
+import { useUploadingError } from '../hooks/useUploadingError';
 
 const DEFAULT_HEIGHT = '30px';
 
@@ -59,8 +60,10 @@ const ChatInput = ({ setShouldAutoScroll }: ChatInputProps) => {
     isSupportedFile: true,
     errorMessage: '',
   });
+  const { setUploadError } = useUploadingError(setUploadingState);
   const { isActive, isSupportedFile, errorMessage } = uploadingState;
 
+  //  todo - fully deprecate
   const resetUploadState = useCallback(() => {
     setUploadingState({
       isActive: false,
@@ -249,15 +252,7 @@ const ChatInput = ({ setShouldAutoScroll }: ChatInputProps) => {
       const totalFilesAfterUpdate =
         uploadedFiles.length + event.target.files.length;
       if (totalFilesAfterUpdate > maximumFileUploads) {
-        setUploadingState({
-          isActive: true,
-          isSupportedFile: false,
-          errorMessage: `Maximum ${maximumFileUploads} files allowed.`,
-        });
-
-        setTimeout(() => {
-          resetUploadState();
-        }, 2000);
+        setUploadError(`Maximum ${maximumFileUploads} files allowed.`);
       } else {
         Array.from(event.target.files).forEach((file) => {
           processUploadedFile(file);

--- a/src/core/hooks/useUploadingError.ts
+++ b/src/core/hooks/useUploadingError.ts
@@ -3,8 +3,10 @@ import { useCallback } from 'react';
 const RESET_DELAY = 2000;
 
 /**
- * Hook that provides function to set upload error state with automatic reset
- * @param setUploadingState - The state setter function
+ * Hook that provides a function to set upload error state with automatic reset
+ *
+ * @param setUploadingState - The state setter function to update the upload state
+ * @returns An object containing the setUploadError function
  */
 export const useUploadingError = (
   setUploadingState: (state: {
@@ -21,6 +23,15 @@ export const useUploadingError = (
     });
   }, [setUploadingState]);
 
+  /**
+   * Sets an upload error state and automatically resets it after a delay
+   *
+   * @param errorMessage - The error message to display
+   * @param isSupportedFile - Whether the file type is supported (defaults to false for error states)
+   *
+   * This function sets the error state with the provided message and automatically resets
+   * the state after {@link RESET_DELAY} milliseconds (2000ms).
+   */
   const setUploadError = useCallback(
     (errorMessage: string, isSupportedFile = false) => {
       setUploadingState({

--- a/src/core/hooks/useUploadingError.ts
+++ b/src/core/hooks/useUploadingError.ts
@@ -1,0 +1,42 @@
+import { useCallback } from 'react';
+
+const RESET_DELAY = 2000;
+
+/**
+ * Hook that provides function to set upload error state with automatic reset
+ * @param setUploadingState - The state setter function
+ */
+export const useUploadingError = (
+  setUploadingState: (state: {
+    isActive: boolean;
+    isSupportedFile: boolean;
+    errorMessage: string;
+  }) => void,
+) => {
+  const resetUploadState = useCallback(() => {
+    setUploadingState({
+      isActive: false,
+      isSupportedFile: true,
+      errorMessage: '',
+    });
+  }, [setUploadingState]);
+
+  const setUploadError = useCallback(
+    (errorMessage: string, isSupportedFile = false) => {
+      setUploadingState({
+        isActive: true,
+        isSupportedFile,
+        errorMessage,
+      });
+
+      setTimeout(() => {
+        resetUploadState();
+      }, RESET_DELAY);
+    },
+    [resetUploadState, setUploadingState],
+  );
+
+  return {
+    setUploadError,
+  };
+};


### PR DESCRIPTION
## Summary
This sets up a new hook to manage setting and clearing the uploading error state. It also replaces two instances of such duplication (uploading too many files & uploading too big a single file). Follow on PR's can address other specific cases to allow for more focused testing.

## Demo

https://github.com/user-attachments/assets/79d195c0-3bf5-44c5-8dee-df578510a684


