### PR TITLE
feat: add brain icon for progress

### DIFF
--- a/src/core/components/Conversation/Conversation.module.css
+++ b/src/core/components/Conversation/Conversation.module.css
@@ -30,6 +30,9 @@
 }
 
 .progressStream {
+  display: flex;
+  align-content: center;
+
   .content {
     color: var(--colors-textTertiary);
     font-size: 1.5rem;
@@ -88,14 +91,61 @@ li {
   left: 0;
 }
 
-@keyframes pulse {
+.brainIconContainer {
+  display: flex;
+  align-items: center;
+  padding: var(--spacing-xs);
+  border-radius: 50%;
+  background: var(--colors-accentTwoBorder);
+  transition: background 0.3s ease;
+  width: fit-content;
+  margin-right: 2rem;
+  height: fit-content;
+}
+
+.brainIcon {
+  color: var(--colors-accentTwo);
+  opacity: 0.7;
+  transition: opacity 0.3s ease;
+  display: block;
+}
+
+.brainIconContainer.pulsing {
+  animation: iconContainerPulse 2s ease-in-out infinite;
+  /* Outer glow */
+  box-shadow: 0 0 8px 2px var(--colors-accentTwo);
+}
+
+.brainIcon.pulsing {
+  animation: iconPulse 2s ease-in-out infinite;
+  /* Make sure the icon remains visible */
+  position: relative;
+  z-index: 2;
+}
+
+@keyframes iconContainerPulse {
   0% {
-    opacity: 0.6;
+    background: rgba(var(--colors-accentTwo), 0.2);
+    box-shadow: 0 0 5px 1px var(--colors-accentTwo);
   }
   50% {
-    opacity: 0.8;
+    background: rgba(var(--colors-accentTwo), 0.6);
+    box-shadow: 0 0 12px 3px var(--colors-accentTwo);
   }
   100% {
-    opacity: 0.6;
+    background: rgba(var(--colors-accentTwo), 0.2);
+    box-shadow: 0 0 5px 1px var(--colors-accentTwo);
+  }
+}
+
+@keyframes iconPulse {
+  0% {
+    opacity: 0.7;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.7;
   }
 }

--- a/src/core/components/Conversation/ProgressIcon.tsx
+++ b/src/core/components/Conversation/ProgressIcon.tsx
@@ -1,0 +1,20 @@
+import styles from './Conversation.module.css';
+import { BrainIcon } from '../../assets/BrainIcon';
+
+interface ProgressIconProps {
+  progressText: string;
+}
+
+export const ProgressIcon = ({ progressText }: ProgressIconProps) => {
+  //  remove when the progress store clears
+  if (progressText.length === 0) return;
+
+  return (
+    <div className={`${styles.brainIconContainer} ${styles.pulsing}`}>
+      <BrainIcon
+        className={`${styles.brainIcon} ${styles.pulsing}`}
+        aria-label="Progress Icon"
+      />
+    </div>
+  );
+};

--- a/src/core/components/Conversation/ProgressStream.tsx
+++ b/src/core/components/Conversation/ProgressStream.tsx
@@ -2,6 +2,8 @@ import styles from './Conversation.module.css';
 import { useAppContext } from '../../context/useAppContext';
 import { StreamingText } from '.././Conversation/StreamingText';
 import { StreamingTextContent } from '.././Conversation/StreamingTextContent';
+import { useSyncExternalStore } from 'react';
+import { ProgressIcon } from './ProgressIcon';
 
 interface ProgressStreamProps {
   onRendered: () => void;
@@ -10,8 +12,14 @@ interface ProgressStreamProps {
 export const ProgressStream = ({ onRendered }: ProgressStreamProps) => {
   const { progressStore } = useAppContext();
 
+  const progressText = useSyncExternalStore(
+    progressStore.subscribe,
+    progressStore.getSnapshot,
+  );
+
   return (
     <div className={styles.progressStream}>
+      <ProgressIcon progressText={progressText} />
       <StreamingText store={progressStore} onRendered={onRendered}>
         {StreamingTextContent}
       </StreamingText>

--- a/src/core/components/Conversation/StreamingText.test.tsx
+++ b/src/core/components/Conversation/StreamingText.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen, act } from '@testing-library/react';
 import { StreamingText } from './StreamingText';
 import { TextStreamStore } from '../../stores/textStreamStore';
+import React from 'react';
+import { AppContext } from '../../context/AppContext';
+import { AppContextType } from '../../context/types';
+import { ProgressStream } from './ProgressStream';
 
 describe('StreamingText', () => {
   it('renders with the initial snapshot of the store', () => {
@@ -189,5 +193,46 @@ describe('StreamingText', () => {
     expect(screen.getByTestId('child')).toHaveTextContent('Updated');
     // Check the parent's render count
     expect(parentRenderCount).toBe(1);
+  });
+
+  it('shows brain icon when progress store has text and hides when empty', () => {
+    const progressStore = new TextStreamStore();
+
+    const mockContext = {
+      progressStore,
+    } as unknown as AppContextType;
+
+    //  Render with empty progress store initially
+    const { rerender } = render(
+      <AppContext.Provider value={mockContext}>
+        <ProgressStream onRendered={() => {}} />
+      </AppContext.Provider>,
+    );
+
+    expect(screen.queryByTestId('brain-icon')).not.toBeInTheDocument();
+
+    act(() => {
+      progressStore.setText('Thinking...');
+    });
+
+    rerender(
+      <AppContext.Provider value={mockContext}>
+        <ProgressStream onRendered={() => {}} />
+      </AppContext.Provider>,
+    );
+
+    expect(screen.getByLabelText('Progress Icon')).toBeInTheDocument();
+
+    act(() => {
+      progressStore.setText('');
+    });
+
+    rerender(
+      <AppContext.Provider value={mockContext}>
+        <ProgressStream onRendered={() => {}} />
+      </AppContext.Provider>,
+    );
+
+    expect(screen.queryByLabelText('Progress Icon')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
When a request is processing, add a pulsing brain icon beside "Thinking..." 
When the progress text clears, so does the icon

## Demo 

https://github.com/user-attachments/assets/ad59efce-8b66-4f18-aa7c-0ac8233c2a30

