### PR TITLE
fix: empty space equal to the image upload for single and multiple

### DIFF
--- a/src/core/components/Conversation/Conversation.module.css
+++ b/src/core/components/Conversation/Conversation.module.css
@@ -94,14 +94,7 @@ li {
 
 .chatImage {
   margin: var(--spacing-xs) 0 var(--spacing-xs) auto;
-}
-
-.imageSkeleton {
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
+  height: 256px;
 }
 
 .brainIconContainer {

--- a/src/core/components/Conversation/Conversation.module.css
+++ b/src/core/components/Conversation/Conversation.module.css
@@ -94,7 +94,7 @@ li {
 
 .chatImage {
   margin: var(--spacing-xs) 0 var(--spacing-xs) auto;
-  height: 256px;
+  height: 290px;
 }
 
 .brainIconContainer {

--- a/src/core/components/Conversation/Conversation.tsx
+++ b/src/core/components/Conversation/Conversation.tsx
@@ -1,5 +1,5 @@
 import styles from './Conversation.module.css';
-import { Fragment, memo, useState } from 'react';
+import { Fragment, memo } from 'react';
 import { useSyncExternalStore } from 'react';
 import { StreamingMessage } from './StreamingMessage';
 import { ErrorMessage } from './ErrorMessage';
@@ -29,11 +29,6 @@ const ConversationComponent = ({ onRendered }: ConversationProps) => {
   );
 
   const { messages } = useMessageHistory();
-  const [isLoaded, setIsLoaded] = useState(false);
-
-  const handleFileLoad = () => {
-    setIsLoaded(true);
-  };
 
   return (
     <div className={styles.conversationContainer} data-testid="conversation">
@@ -91,24 +86,14 @@ const ConversationComponent = ({ onRendered }: ConversationProps) => {
               {hasImage ? (
                 <div className={styles.chatImage}>
                   {imageIDs.length > 1 ? (
-                    <ImageCarousel
-                      imageIDs={imageIDs}
-                      isLoaded={isLoaded}
-                      handleLoaded={handleFileLoad}
-                    />
+                    <ImageCarousel imageIDs={imageIDs} />
                   ) : (
-                    <>
-                      {!isLoaded && (
-                        <div className={styles.imageSkeleton}></div>
-                      )}
-                      <IdbImage
-                        width="256px"
-                        height="256px"
-                        id={imageIDs[0]}
-                        aria-label="File upload chat message"
-                        onLoad={handleFileLoad}
-                      />
-                    </>
+                    <IdbImage
+                      width="256px"
+                      height="256px"
+                      id={imageIDs[0]}
+                      aria-label="File upload chat message"
+                    />
                   )}
                 </div>
               ) : null}

--- a/src/core/components/Conversation/ImageCarousel.tsx
+++ b/src/core/components/Conversation/ImageCarousel.tsx
@@ -3,16 +3,11 @@ import styles from './ImageCarousel.module.css';
 import { IdbImage } from '../IdbImage';
 
 type ImageCarouselProps = {
-  isLoaded: boolean;
-  handleLoaded: () => void;
   imageIDs: string[];
 };
 
-export const ImageCarousel = ({
-  isLoaded,
-  handleLoaded,
-  imageIDs,
-}: ImageCarouselProps) => {
+export const ImageCarousel = ({ imageIDs }: ImageCarouselProps) => {
+  const [isLoaded, setIsLoaded] = useState(false);
   const [slideIndex, setSlideIndex] = useState(1);
 
   //  Function to show current slide
@@ -54,7 +49,7 @@ export const ImageCarousel = ({
               className={styles.image}
               aria-label="File upload chat message"
               //  we only need to update the loading state for the first file
-              onLoad={index === 0 ? handleLoaded : undefined}
+              onLoad={index === 0 ? () => setIsLoaded(true) : undefined}
             />
           </div>
         ))}


### PR DESCRIPTION
## Summary
- defines the parent component for image uploads as the height of the image upload so that it is blank until the image loads and doesn't shift text down

https://github.com/user-attachments/assets/e5b93785-de49-4beb-88fb-53f1129aa42f

- handles the loading state for carousel internally by hiding it until the first image is loaded (otherwise we just get a collapsed version)


https://github.com/user-attachments/assets/993b2fb8-8098-47bc-b50c-52366bf0172d



