### PR TITLE
refactor: lift up start new chat

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { MobileSideBar } from './core/components/MobileSideBar';
 import { MobileBackdrop } from './core/components/MobileBackdrop';
 
 export const App = () => {
-  const { isReady, modelConfig } = useAppContext();
+  const { isReady, modelConfig, startNewChat } = useAppContext();
   const { supportedFileTypes } = modelConfig;
   const isMobile = useIsMobile();
 
@@ -56,7 +56,10 @@ export const App = () => {
             </div>
 
             <div className={styles.sidebarContent}>
-              <ChatHistory onHistoryItemClick={setIsMobileSideBarOpen} />
+              <ChatHistory
+                onHistoryItemClick={setIsMobileSideBarOpen}
+                startNewChat={startNewChat}
+              />
             </div>
           </div>
 
@@ -67,6 +70,7 @@ export const App = () => {
               isPanelOpen={!isDesktopSideBarHidden}
               supportsUpload={supportedFileTypes.length > 0}
               showModelSelector={true}
+              startNewChat={startNewChat}
             />
           </div>
         </div>

--- a/src/core/components/ChatHistory.tsx
+++ b/src/core/components/ChatHistory.tsx
@@ -17,11 +17,14 @@ import ButtonIcon from './ButtonIcon';
 
 interface ChatHistoryProps {
   onHistoryItemClick: Dispatch<SetStateAction<boolean>>;
+  startNewChat: () => void;
 }
 
-export const ChatHistory = ({ onHistoryItemClick }: ChatHistoryProps) => {
-  const { conversationID, loadConversation, conversations, startNewChat } =
-    useAppContext();
+export const ChatHistory = ({
+  onHistoryItemClick,
+  startNewChat,
+}: ChatHistoryProps) => {
+  const { conversationID, loadConversation, conversations } = useAppContext();
 
   const conversationsToRecord = (convs: ConversationHistory[]) => {
     const record: Record<string, ConversationHistory> = {};

--- a/src/core/components/ChatInput.test.tsx
+++ b/src/core/components/ChatInput.test.tsx
@@ -16,6 +16,7 @@ describe('ChatInput', () => {
   const props: ChatInputProps = {
     setShouldAutoScroll: vi.fn(),
     supportsUpload: true,
+    startNewChat: vi.fn(),
   };
 
   test('input is focused by default', () => {

--- a/src/core/components/ChatInput.tsx
+++ b/src/core/components/ChatInput.tsx
@@ -26,6 +26,7 @@ const DEFAULT_HEIGHT = '30px';
 export interface ChatInputProps {
   setShouldAutoScroll: (s: boolean) => void;
   supportsUpload: boolean;
+  startNewChat: () => void;
 }
 
 export interface UploadingState {
@@ -42,7 +43,11 @@ export type FileUpload = {
   page?: number;
 };
 
-const ChatInput = ({ setShouldAutoScroll, supportsUpload }: ChatInputProps) => {
+const ChatInput = ({
+  setShouldAutoScroll,
+  supportsUpload,
+  startNewChat,
+}: ChatInputProps) => {
   const [showInputAdornmentMessage, setShowInputAdornmentMessage] =
     useState(false);
   const [dismissWarning, setDismissWarning] = useState(false);
@@ -369,6 +374,7 @@ const ChatInput = ({ setShouldAutoScroll, supportsUpload }: ChatInputProps) => {
             setShowInputAdornmentMessage(false);
             setDismissWarning(true);
           }}
+          startNewChat={startNewChat}
         />
       )}
       {uploadedFiles.length > 0 && (

--- a/src/core/components/ChatView.tsx
+++ b/src/core/components/ChatView.tsx
@@ -13,6 +13,7 @@ export interface ChatViewProps {
   isPanelOpen: boolean;
   supportsUpload: boolean;
   showModelSelector: boolean;
+  startNewChat: () => void;
 }
 
 export const ChatView = ({
@@ -21,6 +22,7 @@ export const ChatView = ({
   isPanelOpen,
   supportsUpload,
   showModelSelector,
+  startNewChat,
 }: ChatViewProps) => {
   const { hasMessages } = useMessageHistory();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -76,6 +78,7 @@ export const ChatView = ({
             isPanelOpen={isPanelOpen}
             onMenu={onMenu}
             showModelSelector={showModelSelector}
+            startNewChat={startNewChat}
           />
         </div>
 
@@ -95,6 +98,7 @@ export const ChatView = ({
             <ChatInput
               setShouldAutoScroll={setShouldAutoScroll}
               supportsUpload={supportsUpload}
+              startNewChat={startNewChat}
             />
             <div className={styles.importantInfo}>
               <span>{defaultCautionText}</span>

--- a/src/core/components/InputAdornmentMessage.tsx
+++ b/src/core/components/InputAdornmentMessage.tsx
@@ -2,19 +2,18 @@ import React from 'react';
 import styles from './InputAdornmentMessage.module.css';
 import ButtonIcon from './ButtonIcon';
 import { X as CloseX } from 'lucide-react';
-import { useAppContext } from '../context/useAppContext';
 
 interface InputAdornmentMessageProps {
   onCloseClick: () => void;
   shouldDisableChat: boolean;
+  startNewChat: () => void;
 }
 
 export const InputAdornmentMessage: React.FC<InputAdornmentMessageProps> = ({
   onCloseClick,
   shouldDisableChat,
+  startNewChat,
 }) => {
-  const { startNewChat } = useAppContext();
-
   const warningText = shouldDisableChat
     ? 'This conversation has exceeded the context limit'
     : 'This conversation is approaching the context limit';

--- a/src/core/components/NavBar.test.tsx
+++ b/src/core/components/NavBar.test.tsx
@@ -35,6 +35,7 @@ describe('NavBar', () => {
     onPanelOpen: vi.fn(),
     isPanelOpen: false,
     showModelSelector: true,
+    startNewChat: vi.fn(),
   };
 
   beforeEach(() => {

--- a/src/core/components/NavBar.tsx
+++ b/src/core/components/NavBar.tsx
@@ -4,13 +4,13 @@ import { Menu, PanelLeftOpen } from 'lucide-react';
 import ButtonIcon from './ButtonIcon';
 import { NewChatButton } from '../assets/NewChatButton';
 import { ModelSelector } from './ModelSelector';
-import { useAppContext } from '../context/useAppContext';
 
 export interface NavBarProps {
-  onMenu(): void;
-  onPanelOpen(): void;
+  onMenu: () => void;
+  onPanelOpen: () => void;
   isPanelOpen: boolean;
   showModelSelector: boolean;
+  startNewChat: () => void;
 }
 
 export const NavBar = ({
@@ -18,10 +18,9 @@ export const NavBar = ({
   onPanelOpen,
   isPanelOpen,
   showModelSelector,
+  startNewChat,
 }: NavBarProps) => {
   const isMobile = useIsMobile();
-
-  const { startNewChat } = useAppContext();
 
   return (
     <div className={styles.nav}>

--- a/src/stories/ChatView.stories.tsx
+++ b/src/stories/ChatView.stories.tsx
@@ -75,6 +75,7 @@ const args: ChatViewProps = {
   isPanelOpen: false,
   supportsUpload: true,
   showModelSelector: true,
+  startNewChat: fn(),
 };
 
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args


### PR DESCRIPTION
## Summary
Pulls `startNewChat` from app context in App and then passes it down as props to the children that need it