### PR TITLE
refactor: containerize chat

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
-import { ChatView } from './core/components/ChatView';
 import { useChat } from './core/context/useChat';
 import styles from './App.module.css';
 import KavaAILogo from './core/assets/KavaAILogo';
 import { SearchHistoryModal, SideBar, useIsMobileLayout } from 'lib-kava-ai';
 import { useSession } from './useSession';
+import { ChatViewContainer } from './core/components/ChatViewContainer';
 
 export const App = () => {
   const {
@@ -70,24 +70,42 @@ export const App = () => {
             styles={styles}
           />
           <div className={styles.content}>
-            <ChatView
-              handleModelChange={handleModelChange}
-              thinkingStore={thinkingStore}
-              messageHistoryStore={messageHistoryStore}
-              isRequesting={isRequesting}
-              errorStore={errorStore}
-              messageStore={messageStore}
-              handleCancel={handleCancel}
-              handleChatCompletion={handleChatCompletion}
+            <ChatViewContainer
               onMenu={() => setIsMobileSideBarOpen(true)}
               onPanelOpen={() => setIsDesktopSideBarOpen(true)}
-              isPanelOpen={isDesktopSideBarOpen}
+              isPanelOpen={isDesktopSideBarOpen || isMobileSideBarOpen}
               supportsUpload={supportedFileTypes.length > 0}
               showModelSelector={true}
               startNewChat={startNewChat}
               conversationID={conversationID}
               modelConfig={modelConfig}
+              errorStore={errorStore}
+              messageStore={messageStore}
+              thinkingStore={thinkingStore}
+              messageHistoryStore={messageHistoryStore}
+              isRequesting={isRequesting}
+              handleChatCompletion={handleChatCompletion}
+              handleCancel={handleCancel}
+              handleModelChange={handleModelChange}
             />
+            {/*<ChatView*/}
+            {/*  handleModelChange={handleModelChange}*/}
+            {/*  thinkingStore={thinkingStore}*/}
+            {/*  messageHistoryStore={messageHistoryStore}*/}
+            {/*  isRequesting={isRequesting}*/}
+            {/*  errorStore={errorStore}*/}
+            {/*  messageStore={messageStore}*/}
+            {/*  handleCancel={handleCancel}*/}
+            {/*  handleChatCompletion={handleChatCompletion}*/}
+            {/*  onMenu={() => setIsMobileSideBarOpen(true)}*/}
+            {/*  onPanelOpen={() => setIsDesktopSideBarOpen(true)}*/}
+            {/*  isPanelOpen={isDesktopSideBarOpen}*/}
+            {/*  supportsUpload={supportedFileTypes.length > 0}*/}
+            {/*  showModelSelector={true}*/}
+            {/*  startNewChat={startNewChat}*/}
+            {/*  conversationID={conversationID}*/}
+            {/*  modelConfig={modelConfig}*/}
+            {/*/>*/}
           </div>
           {isSearchHistoryOpen && searchableHistory && (
             <SearchHistoryModal

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,14 @@ export const App = () => {
           />
           <div className={styles.content}>
             <ChatViewContainer
+              handleModelChange={handleModelChange}
+              thinkingStore={thinkingStore}
+              messageHistoryStore={messageHistoryStore}
+              isRequesting={isRequesting}
+              errorStore={errorStore}
+              messageStore={messageStore}
+              handleCancel={handleCancel}
+              handleChatCompletion={handleChatCompletion}
               onMenu={() => setIsMobileSideBarOpen(true)}
               onPanelOpen={() => setIsDesktopSideBarOpen(true)}
               isPanelOpen={isDesktopSideBarOpen}
@@ -79,14 +87,6 @@ export const App = () => {
               startNewChat={startNewChat}
               conversationID={conversationID}
               modelConfig={modelConfig}
-              errorStore={errorStore}
-              messageStore={messageStore}
-              thinkingStore={thinkingStore}
-              messageHistoryStore={messageHistoryStore}
-              isRequesting={isRequesting}
-              handleChatCompletion={handleChatCompletion}
-              handleCancel={handleCancel}
-              handleModelChange={handleModelChange}
             />
           </div>
           {isSearchHistoryOpen && searchableHistory && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,7 @@ export const App = () => {
             <ChatViewContainer
               onMenu={() => setIsMobileSideBarOpen(true)}
               onPanelOpen={() => setIsDesktopSideBarOpen(true)}
-              isPanelOpen={isDesktopSideBarOpen || isMobileSideBarOpen}
+              isPanelOpen={isDesktopSideBarOpen}
               supportsUpload={supportedFileTypes.length > 0}
               showModelSelector={true}
               startNewChat={startNewChat}
@@ -88,24 +88,6 @@ export const App = () => {
               handleCancel={handleCancel}
               handleModelChange={handleModelChange}
             />
-            {/*<ChatView*/}
-            {/*  handleModelChange={handleModelChange}*/}
-            {/*  thinkingStore={thinkingStore}*/}
-            {/*  messageHistoryStore={messageHistoryStore}*/}
-            {/*  isRequesting={isRequesting}*/}
-            {/*  errorStore={errorStore}*/}
-            {/*  messageStore={messageStore}*/}
-            {/*  handleCancel={handleCancel}*/}
-            {/*  handleChatCompletion={handleChatCompletion}*/}
-            {/*  onMenu={() => setIsMobileSideBarOpen(true)}*/}
-            {/*  onPanelOpen={() => setIsDesktopSideBarOpen(true)}*/}
-            {/*  isPanelOpen={isDesktopSideBarOpen}*/}
-            {/*  supportsUpload={supportedFileTypes.length > 0}*/}
-            {/*  showModelSelector={true}*/}
-            {/*  startNewChat={startNewChat}*/}
-            {/*  conversationID={conversationID}*/}
-            {/*  modelConfig={modelConfig}*/}
-            {/*/>*/}
           </div>
           {isSearchHistoryOpen && searchableHistory && (
             <SearchHistoryModal

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,6 @@ import { ChatViewContainer } from './core/components/ChatViewContainer';
 
 export const App = () => {
   const {
-    isRequesting,
     isReady,
     modelConfig,
     startNewChat,
@@ -19,13 +18,10 @@ export const App = () => {
     conversations,
     searchableHistory,
     fetchSearchHistory,
-    messageHistoryStore,
-    errorStore,
-    messageStore,
     handleCancel,
     handleChatCompletion,
-    thinkingStore,
     handleModelChange,
+    activeConversation,
   } = useChat();
 
   const { supportedFileTypes } = modelConfig;
@@ -72,11 +68,7 @@ export const App = () => {
           <div className={styles.content}>
             <ChatViewContainer
               handleModelChange={handleModelChange}
-              thinkingStore={thinkingStore}
-              messageHistoryStore={messageHistoryStore}
-              isRequesting={isRequesting}
-              errorStore={errorStore}
-              messageStore={messageStore}
+              activeConversation={activeConversation}
               handleCancel={handleCancel}
               handleChatCompletion={handleChatCompletion}
               onMenu={() => setIsMobileSideBarOpen(true)}

--- a/src/core/components/ChatView.tsx
+++ b/src/core/components/ChatView.tsx
@@ -11,8 +11,8 @@ import type { ChatCompletionMessageParam } from 'openai/resources/index';
 import { ChatMessage } from '../stores/messageHistoryStore';
 
 export interface ChatViewProps {
-  onMenu(): void;
-  onPanelOpen(): void;
+  onMenu: () => void;
+  onPanelOpen: () => void;
   isPanelOpen: boolean;
   supportsUpload: boolean;
   showModelSelector: boolean;
@@ -91,7 +91,8 @@ export const ChatView = ({
     }
   }, [shouldAutoScroll, scrollToBottom]);
 
-  const isConversationStarted = messages.length > 0;
+  //  don't include system prompt
+  const isConversationStarted = messages.length > 1;
 
   return (
     <div className={styles.chatview} data-testid="chatview">

--- a/src/core/components/ChatViewContainer.tsx
+++ b/src/core/components/ChatViewContainer.tsx
@@ -6,8 +6,8 @@ import { useMessageHistory } from '../hooks/useMessageHistory';
 import { MessageHistoryStore } from '../stores/messageHistoryStore';
 
 interface ChatViewContainerProps {
-  onMenu(): void;
-  onPanelOpen(): void;
+  onMenu: () => void;
+  onPanelOpen: () => void;
   isPanelOpen: boolean;
   supportsUpload: boolean;
   showModelSelector: boolean;

--- a/src/core/components/ChatViewContainer.tsx
+++ b/src/core/components/ChatViewContainer.tsx
@@ -1,9 +1,8 @@
 import { ChatView } from './ChatView';
 import { ModelConfig, SupportedModels } from '../types/models';
-import type { TextStreamStore } from 'lib-kava-ai';
 import type { ChatCompletionMessageParam } from 'openai/resources';
 import { useMessageHistory } from '../hooks/useMessageHistory';
-import { MessageHistoryStore } from '../stores/messageHistoryStore';
+import { ActiveConversation } from '../context/types';
 
 interface ChatViewContainerProps {
   onMenu: () => void;
@@ -14,11 +13,7 @@ interface ChatViewContainerProps {
   startNewChat: () => void;
   conversationID: string;
   modelConfig: ModelConfig;
-  errorStore: TextStreamStore;
-  messageStore: TextStreamStore;
-  thinkingStore: TextStreamStore;
-  messageHistoryStore: MessageHistoryStore;
-  isRequesting: boolean;
+  activeConversation: ActiveConversation;
   handleChatCompletion: (value: ChatCompletionMessageParam[]) => void;
   handleCancel: () => void;
   handleModelChange: (modelName: SupportedModels) => void;
@@ -31,24 +26,22 @@ export const ChatViewContainer = ({
   handleModelChange,
   handleCancel,
   handleChatCompletion,
-  thinkingStore,
-  messageHistoryStore,
-  isRequesting,
-  errorStore,
-  messageStore,
+  activeConversation,
   startNewChat,
   modelConfig,
   conversationID,
 }: ChatViewContainerProps) => {
-  const { messages } = useMessageHistory(messageHistoryStore);
+  const { messages } = useMessageHistory(
+    activeConversation.messageHistoryStore,
+  );
 
   return (
     <ChatView
       handleModelChange={handleModelChange}
-      thinkingStore={thinkingStore}
-      isRequesting={isRequesting}
-      errorStore={errorStore}
-      messageStore={messageStore}
+      thinkingStore={activeConversation.thinkingStore}
+      isRequesting={activeConversation.isRequesting}
+      errorStore={activeConversation.errorStore}
+      messageStore={activeConversation.messageStore}
       handleCancel={handleCancel}
       handleChatCompletion={handleChatCompletion}
       onMenu={onMenu}

--- a/src/core/components/ChatViewContainer.tsx
+++ b/src/core/components/ChatViewContainer.tsx
@@ -1,0 +1,65 @@
+import { ChatView } from './ChatView';
+import { ModelConfig, SupportedModels } from '../types/models';
+import type { TextStreamStore } from 'lib-kava-ai';
+import type { ChatCompletionMessageParam } from 'openai/resources';
+import { useMessageHistory } from '../hooks/useMessageHistory';
+import { MessageHistoryStore } from '../stores/messageHistoryStore';
+
+interface ChatViewContainerProps {
+  onMenu(): void;
+  onPanelOpen(): void;
+  isPanelOpen: boolean;
+  supportsUpload: boolean;
+  showModelSelector: boolean;
+  startNewChat: () => void;
+  conversationID: string;
+  modelConfig: ModelConfig;
+  errorStore: TextStreamStore;
+  messageStore: TextStreamStore;
+  thinkingStore: TextStreamStore;
+  messageHistoryStore: MessageHistoryStore;
+  isRequesting: boolean;
+  handleChatCompletion: (value: ChatCompletionMessageParam[]) => void;
+  handleCancel: () => void;
+  handleModelChange: (modelName: SupportedModels) => void;
+}
+export const ChatViewContainer = ({
+  onMenu,
+  onPanelOpen,
+  isPanelOpen,
+  supportsUpload,
+  handleModelChange,
+  handleCancel,
+  handleChatCompletion,
+  thinkingStore,
+  messageHistoryStore,
+  isRequesting,
+  errorStore,
+  messageStore,
+  startNewChat,
+  modelConfig,
+  conversationID,
+}: ChatViewContainerProps) => {
+  const { messages } = useMessageHistory(messageHistoryStore);
+
+  return (
+    <ChatView
+      handleModelChange={handleModelChange}
+      thinkingStore={thinkingStore}
+      isRequesting={isRequesting}
+      errorStore={errorStore}
+      messageStore={messageStore}
+      handleCancel={handleCancel}
+      handleChatCompletion={handleChatCompletion}
+      onMenu={onMenu}
+      onPanelOpen={onPanelOpen}
+      isPanelOpen={isPanelOpen}
+      supportsUpload={supportsUpload}
+      showModelSelector={true}
+      startNewChat={startNewChat}
+      conversationID={conversationID}
+      modelConfig={modelConfig}
+      messages={messages}
+    />
+  );
+};

--- a/src/core/components/Conversation/Conversation.test.tsx
+++ b/src/core/components/Conversation/Conversation.test.tsx
@@ -3,7 +3,7 @@ import { vi } from 'vitest';
 import { Conversation } from './Conversation';
 import { useMessageHistory } from '../../hooks/useMessageHistory';
 import { MODEL_REGISTRY } from '../../config';
-import { MessageHistoryStore } from '../../stores/messageHistoryStore';
+import { ChatMessage } from '../../stores/messageHistoryStore';
 import { TextStreamStore } from 'lib-kava-ai';
 
 // Mock the required modules and hooks
@@ -85,7 +85,7 @@ describe('Conversation', () => {
   it('renders empty conversation correctly', () => {
     render(
       <Conversation
-        messageHistoryStore={new MessageHistoryStore()}
+        messages={[]}
         errorStore={new TextStreamStore()}
         messageStore={new TextStreamStore()}
         isRequesting={false}
@@ -99,15 +99,14 @@ describe('Conversation', () => {
   });
 
   it.skip('renders user messages correctly', () => {
-    const messageHistoryStore = new MessageHistoryStore();
-    messageHistoryStore.setMessages([
+    const mockMessages = [
       { role: 'user', content: 'Hello' },
       { role: 'user', content: 'How are you?' },
-    ]);
+    ] as ChatMessage[];
 
     render(
       <Conversation
-        messageHistoryStore={messageHistoryStore}
+        messages={mockMessages}
         errorStore={new TextStreamStore()}
         messageStore={new TextStreamStore()}
         isRequesting={false}
@@ -124,20 +123,18 @@ describe('Conversation', () => {
   });
 
   it('renders assistant messages correctly', () => {
-    (useMessageHistory as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      messages: [
-        { role: 'assistant', content: 'I am an AI assistant' },
-        {
-          role: 'assistant',
-          content: 'How can I help?',
-          reasoningContent: 'Thinking about response',
-        },
-      ],
-    });
+    const mockMessages = [
+      { role: 'assistant', content: 'I am an AI assistant' },
+      {
+        role: 'assistant',
+        content: 'How can I help?',
+        reasoningContent: 'Thinking about response',
+      },
+    ] as ChatMessage[];
 
     render(
       <Conversation
-        messageHistoryStore={new MessageHistoryStore()}
+        messages={mockMessages}
         errorStore={new TextStreamStore()}
         messageStore={new TextStreamStore()}
         isRequesting={false}
@@ -159,7 +156,7 @@ describe('Conversation', () => {
   it('renders progress icon when isRequesting is true before assistant stream starts', () => {
     render(
       <Conversation
-        messageHistoryStore={new MessageHistoryStore()}
+        messages={[]}
         errorStore={new TextStreamStore()}
         messageStore={new TextStreamStore()}
         isRequesting={true}
@@ -175,7 +172,7 @@ describe('Conversation', () => {
   it('hides progress icon when isRequesting is true and assistant stream starts', () => {
     render(
       <Conversation
-        messageHistoryStore={new MessageHistoryStore()}
+        messages={[]}
         errorStore={new TextStreamStore()}
         messageStore={new TextStreamStore()}
         isRequesting={false}
@@ -196,7 +193,7 @@ describe('Conversation', () => {
 
     render(
       <Conversation
-        messageHistoryStore={new MessageHistoryStore()}
+        messages={[]}
         errorStore={errorStore}
         messageStore={new TextStreamStore()}
         isRequesting={false}

--- a/src/core/components/Conversation/Conversation.test.tsx
+++ b/src/core/components/Conversation/Conversation.test.tsx
@@ -1,25 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import { Conversation } from './Conversation';
-import { useMessageHistory } from '../../hooks/useMessageHistory';
 import { MODEL_REGISTRY } from '../../config';
 import { ChatMessage } from '../../stores/messageHistoryStore';
 import { TextStreamStore } from 'lib-kava-ai';
-
-// Mock the required modules and hooks
-// TODO: Consider using AppContext so the data structure remains
-//       the same instead of potentially producing false positives
-vi.mock('../../context/useAppContext');
-vi.mock('../../hooks/useMessageHistory');
-vi.mock('react', async () => {
-  const actual = await vi.importActual('react');
-  return {
-    ...actual,
-    useSyncExternalStore: vi
-      .fn()
-      .mockImplementation((_, getSnapshot) => getSnapshot()),
-  };
-});
 
 // Mock the child components to reduce other component dependencies
 vi.mock('./UserMessage', () => ({
@@ -76,10 +60,6 @@ describe('Conversation', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-
-    (useMessageHistory as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      messages: [],
-    });
   });
 
   it('renders empty conversation correctly', () => {
@@ -99,10 +79,10 @@ describe('Conversation', () => {
   });
 
   it.skip('renders user messages correctly', () => {
-    const mockMessages = [
+    const mockMessages: ChatMessage[] = [
       { role: 'user', content: 'Hello' },
       { role: 'user', content: 'How are you?' },
-    ] as ChatMessage[];
+    ];
 
     render(
       <Conversation
@@ -123,14 +103,14 @@ describe('Conversation', () => {
   });
 
   it('renders assistant messages correctly', () => {
-    const mockMessages = [
+    const mockMessages: ChatMessage[] = [
       { role: 'assistant', content: 'I am an AI assistant' },
       {
         role: 'assistant',
         content: 'How can I help?',
         reasoningContent: 'Thinking about response',
       },
-    ] as ChatMessage[];
+    ];
 
     render(
       <Conversation

--- a/src/core/components/Conversation/Conversation.tsx
+++ b/src/core/components/Conversation/Conversation.tsx
@@ -4,14 +4,13 @@ import { useSyncExternalStore } from 'react';
 import { StreamingMessage } from './StreamingMessage';
 import { ErrorMessage } from './ErrorMessage';
 import AssistantMessage from './AssistantMessage';
-import { useMessageHistory } from '../../hooks/useMessageHistory';
 import { Content } from './Content';
 import { IdbImage } from '../IdbImage';
 import { ImageCarousel } from './ImageCarousel';
 import { ProgressIcon } from './ProgressIcon';
 import { ModelConfig } from '../../types/models';
-import { MessageHistoryStore } from '../../stores/messageHistoryStore';
 import { TextStreamStore } from 'lib-kava-ai';
+import { ChatMessage } from '../../stores/messageHistoryStore';
 
 export interface ConversationProps {
   isRequesting: boolean;
@@ -19,7 +18,7 @@ export interface ConversationProps {
   modelConfig: ModelConfig;
   errorStore: TextStreamStore;
   messageStore: TextStreamStore;
-  messageHistoryStore: MessageHistoryStore;
+  messages: ChatMessage[];
   thinkingStore: TextStreamStore;
 }
 
@@ -29,7 +28,7 @@ const ConversationComponent = ({
   modelConfig,
   errorStore,
   messageStore,
-  messageHistoryStore,
+  messages,
   thinkingStore,
 }: ConversationProps) => {
   const errorText: string = useSyncExternalStore(
@@ -41,8 +40,6 @@ const ConversationComponent = ({
     messageStore.subscribe,
     messageStore.getSnapshot,
   );
-
-  const { messages } = useMessageHistory(messageHistoryStore);
 
   return (
     <div className={styles.conversationContainer} data-testid="conversation">

--- a/src/core/components/ModelSelector.test.tsx
+++ b/src/core/components/ModelSelector.test.tsx
@@ -3,7 +3,6 @@ import { ModelSelector } from './ModelSelector';
 import { useIsMobileLayout } from 'lib-kava-ai';
 import { getAllModels } from '../config/models/index';
 import { vi } from 'vitest';
-import { MessageHistoryStore } from '../stores/messageHistoryStore';
 import { ModelConfig } from '../types/models';
 
 // Mock the required modules and hooks
@@ -58,7 +57,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={vi.fn()}
         modelConfig={mockReasoningModel as unknown as ModelConfig}
-        messageHistoryStore={new MessageHistoryStore()}
+        isModelSelectorDisabled={false}
       />,
     );
 
@@ -73,7 +72,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={vi.fn()}
         modelConfig={mockReasoningModel as unknown as ModelConfig}
-        messageHistoryStore={new MessageHistoryStore()}
+        isModelSelectorDisabled={false}
       />,
     );
 
@@ -89,7 +88,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={vi.fn()}
         modelConfig={getAllModels()[0]}
-        messageHistoryStore={new MessageHistoryStore()}
+        isModelSelectorDisabled={false}
       />,
     );
 
@@ -120,7 +119,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={mockHandleModelChange}
         modelConfig={getAllModels()[0]}
-        messageHistoryStore={new MessageHistoryStore()}
+        isModelSelectorDisabled={false}
       />,
     );
 
@@ -136,7 +135,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={vi.fn()}
         modelConfig={getAllModels()[0]}
-        messageHistoryStore={new MessageHistoryStore()}
+        isModelSelectorDisabled={false}
       />,
     );
 
@@ -147,34 +146,12 @@ describe('ModelSelector', () => {
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
   });
 
-  it('disables selector when chat has messages', () => {
-    const messageHistoryStore = new MessageHistoryStore();
-    messageHistoryStore.setMessages([
-      { role: 'user', content: 'Hello' },
-      { role: 'assistant', content: 'Hi' },
-    ]);
-
-    render(
-      <ModelSelector
-        handleModelChange={mockHandleModelChange}
-        modelConfig={getAllModels()[0]}
-        messageHistoryStore={messageHistoryStore}
-      />,
-    );
-
-    const combobox = screen.getByRole('combobox', { name: 'Select Model' });
-    expect(combobox).toBeDisabled();
-
-    fireEvent.click(combobox);
-    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
-  });
-
   it('marks current model as selected', () => {
     render(
       <ModelSelector
         handleModelChange={vi.fn()}
         modelConfig={getAllModels()[0]}
-        messageHistoryStore={new MessageHistoryStore()}
+        isModelSelectorDisabled={false}
       />,
     );
 
@@ -193,7 +170,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={mockHandleModelChange}
         modelConfig={mockBlockchainModel as unknown as ModelConfig}
-        messageHistoryStore={new MessageHistoryStore()}
+        isModelSelectorDisabled={false}
       />,
     );
 
@@ -243,7 +220,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={vi.fn()}
         modelConfig={mockReasoningModel as unknown as ModelConfig}
-        messageHistoryStore={new MessageHistoryStore()}
+        isModelSelectorDisabled={false}
       />,
     );
     expect(screen.getByTestId('kava-icon')).toBeInTheDocument();
@@ -252,7 +229,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={vi.fn()}
         modelConfig={mockBlockchainModel as unknown as ModelConfig}
-        messageHistoryStore={new MessageHistoryStore()}
+        isModelSelectorDisabled={false}
       />,
     );
     expect(screen.getByTestId('oros-icon')).toBeInTheDocument();

--- a/src/core/components/ModelSelector.test.tsx
+++ b/src/core/components/ModelSelector.test.tsx
@@ -57,7 +57,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={vi.fn()}
         modelConfig={mockReasoningModel as unknown as ModelConfig}
-        isModelSelectorDisabled={false}
+        isDisabled={false}
       />,
     );
 
@@ -72,7 +72,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={vi.fn()}
         modelConfig={mockReasoningModel as unknown as ModelConfig}
-        isModelSelectorDisabled={false}
+        isDisabled={false}
       />,
     );
 
@@ -88,7 +88,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={vi.fn()}
         modelConfig={getAllModels()[0]}
-        isModelSelectorDisabled={false}
+        isDisabled={false}
       />,
     );
 
@@ -119,7 +119,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={mockHandleModelChange}
         modelConfig={getAllModels()[0]}
-        isModelSelectorDisabled={false}
+        isDisabled={false}
       />,
     );
 
@@ -135,7 +135,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={vi.fn()}
         modelConfig={getAllModels()[0]}
-        isModelSelectorDisabled={false}
+        isDisabled={false}
       />,
     );
 
@@ -151,7 +151,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={vi.fn()}
         modelConfig={getAllModels()[0]}
-        isModelSelectorDisabled={false}
+        isDisabled={false}
       />,
     );
 
@@ -170,7 +170,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={mockHandleModelChange}
         modelConfig={mockBlockchainModel as unknown as ModelConfig}
-        isModelSelectorDisabled={false}
+        isDisabled={false}
       />,
     );
 
@@ -220,7 +220,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={vi.fn()}
         modelConfig={mockReasoningModel as unknown as ModelConfig}
-        isModelSelectorDisabled={false}
+        isDisabled={false}
       />,
     );
     expect(screen.getByTestId('kava-icon')).toBeInTheDocument();
@@ -229,7 +229,7 @@ describe('ModelSelector', () => {
       <ModelSelector
         handleModelChange={vi.fn()}
         modelConfig={mockBlockchainModel as unknown as ModelConfig}
-        isModelSelectorDisabled={false}
+        isDisabled={false}
       />,
     );
     expect(screen.getByTestId('oros-icon')).toBeInTheDocument();

--- a/src/core/components/ModelSelector.tsx
+++ b/src/core/components/ModelSelector.tsx
@@ -2,36 +2,21 @@ import styles from './ModelSelector.module.css';
 import { useEffect, useState } from 'react';
 import { getAllModels } from '../config';
 import { ModelConfig, SupportedModels } from '../types/models';
-import type { MessageHistoryStore } from '../stores/messageHistoryStore';
 
 export const ModelSelector = ({
   modelConfig,
-  messageHistoryStore,
+  isModelSelectorDisabled,
   handleModelChange,
 }: {
   handleModelChange: (modelName: SupportedModels) => void;
   modelConfig: ModelConfig;
-  messageHistoryStore: MessageHistoryStore;
+  isModelSelectorDisabled: boolean;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [isDisabled, setIsDisabled] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(0); // For keyboard navigation
 
   const SelectedModelIcon = modelConfig.icon;
   const models = getAllModels();
-
-  // Check for existing messages to determine disabled state
-  const messages = messageHistoryStore.getSnapshot();
-  const hasUserMessages = messages.length > 1;
-
-  useEffect(() => {
-    if (hasUserMessages) {
-      setIsDisabled(true);
-      setIsOpen(false);
-    } else {
-      setIsDisabled(false);
-    }
-  }, [hasUserMessages]);
 
   // Handle click outside to close dropdown
   useEffect(() => {
@@ -90,8 +75,8 @@ export const ModelSelector = ({
     <div className={styles.dropdownContainer}>
       <button
         className={styles.dropdownButton}
-        onClick={() => !isDisabled && setIsOpen(!isOpen)}
-        disabled={isDisabled}
+        onClick={() => !isModelSelectorDisabled && setIsOpen(!isOpen)}
+        disabled={isModelSelectorDisabled}
         aria-expanded={isOpen}
         aria-haspopup="listbox"
         aria-label="Select Model"

--- a/src/core/components/ModelSelector.tsx
+++ b/src/core/components/ModelSelector.tsx
@@ -5,12 +5,12 @@ import { ModelConfig, SupportedModels } from '../types/models';
 
 export const ModelSelector = ({
   modelConfig,
-  isModelSelectorDisabled,
+  isDisabled,
   handleModelChange,
 }: {
   handleModelChange: (modelName: SupportedModels) => void;
   modelConfig: ModelConfig;
-  isModelSelectorDisabled: boolean;
+  isDisabled: boolean;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(0); // For keyboard navigation
@@ -75,8 +75,8 @@ export const ModelSelector = ({
     <div className={styles.dropdownContainer}>
       <button
         className={styles.dropdownButton}
-        onClick={() => !isModelSelectorDisabled && setIsOpen(!isOpen)}
-        disabled={isModelSelectorDisabled}
+        onClick={() => !isDisabled && setIsOpen(!isOpen)}
+        disabled={isDisabled}
         aria-expanded={isOpen}
         aria-haspopup="listbox"
         aria-label="Select Model"

--- a/src/core/components/NavBar.test.tsx
+++ b/src/core/components/NavBar.test.tsx
@@ -2,11 +2,6 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 import { NavBar, NavBarProps } from './NavBar';
 import { useIsMobileLayout } from 'lib-kava-ai';
-
-import { MessageHistoryStore } from '../stores/messageHistoryStore';
-
-const messageHistoryStore = new MessageHistoryStore();
-
 import * as useIsMobileLayoutModule from 'lib-kava-ai';
 import { getModelConfig } from '../config';
 
@@ -41,7 +36,7 @@ describe('NavBar', () => {
     isPanelOpen: false,
     showModelSelector: true,
     startNewChat: vi.fn(),
-    messageHistoryStore,
+    isModelSelectorDisabled: false,
     handleModelChange: vi.fn(),
     modelConfig: getModelConfig('o3-mini'),
   };

--- a/src/core/components/NavBar.tsx
+++ b/src/core/components/NavBar.tsx
@@ -5,7 +5,6 @@ import ButtonIcon from './ButtonIcon';
 import { NewChatButton } from '../assets/NewChatButton';
 import { ModelSelector } from './ModelSelector';
 import type { SupportedModels, ModelConfig } from '../types/models';
-import type { MessageHistoryStore } from '../stores/messageHistoryStore';
 
 export interface NavBarProps {
   onMenu: () => void;
@@ -15,7 +14,7 @@ export interface NavBarProps {
   startNewChat: () => void;
   handleModelChange: (modelName: SupportedModels) => void;
   modelConfig: ModelConfig;
-  messageHistoryStore: MessageHistoryStore;
+  isModelSelectorDisabled: boolean;
 }
 
 export const NavBar = ({
@@ -26,7 +25,7 @@ export const NavBar = ({
   startNewChat,
   handleModelChange,
   modelConfig,
-  messageHistoryStore,
+  isModelSelectorDisabled,
 }: NavBarProps) => {
   const isMobileLayout = useIsMobileLayout();
 
@@ -54,7 +53,7 @@ export const NavBar = ({
               <ModelSelector
                 handleModelChange={handleModelChange}
                 modelConfig={modelConfig}
-                messageHistoryStore={messageHistoryStore}
+                isModelSelectorDisabled={isModelSelectorDisabled}
               />
             )}
           </div>
@@ -78,7 +77,7 @@ export const NavBar = ({
           <ModelSelector
             handleModelChange={handleModelChange}
             modelConfig={modelConfig}
-            messageHistoryStore={messageHistoryStore}
+            isModelSelectorDisabled={isModelSelectorDisabled}
           />
         )}
       </div>

--- a/src/core/components/NavBar.tsx
+++ b/src/core/components/NavBar.tsx
@@ -53,7 +53,7 @@ export const NavBar = ({
               <ModelSelector
                 handleModelChange={handleModelChange}
                 modelConfig={modelConfig}
-                isModelSelectorDisabled={isModelSelectorDisabled}
+                isDisabled={isModelSelectorDisabled}
               />
             )}
           </div>
@@ -77,7 +77,7 @@ export const NavBar = ({
           <ModelSelector
             handleModelChange={handleModelChange}
             modelConfig={modelConfig}
-            isModelSelectorDisabled={isModelSelectorDisabled}
+            isDisabled={isModelSelectorDisabled}
           />
         )}
       </div>

--- a/src/core/context/useChat.tsx
+++ b/src/core/context/useChat.tsx
@@ -96,7 +96,6 @@ export const useChat = (props?: {
     messageStore,
     progressStore,
     thinkingStore,
-    errorStore,
   } = conversation;
 
   const activeConversationsRef = useRef<Map<string, ActiveConversation>>(null);
@@ -341,16 +340,11 @@ export const useChat = (props?: {
   return {
     conversationID,
     client,
-    messageHistoryStore,
-    messageStore,
-    progressStore,
     modelConfig,
     handleModelChange,
     startNewChat,
     handleCancel,
     handleChatCompletion,
-    thinkingStore,
-    errorStore,
     onSelectConversation,
     onDeleteConversation,
     onUpdateConversationTitle,
@@ -359,5 +353,6 @@ export const useChat = (props?: {
     fetchSearchHistory,
     searchableHistory,
     conversations: conversationHistories,
+    activeConversation: conversation,
   };
 };

--- a/src/stories/ChatView.stories.tsx
+++ b/src/stories/ChatView.stories.tsx
@@ -67,7 +67,7 @@ const args: ChatViewProps = {
   startNewChat: fn(),
   conversationID: 'foo',
   modelConfig: MODEL_REGISTRY['o3-mini'],
-  messageHistoryStore: messageHistoryStore,
+  messages: [],
   errorStore: new TextStreamStore(),
   messageStore: new TextStreamStore(),
   thinkingStore: new TextStreamStore(),


### PR DESCRIPTION
## Summary
Now that we've migrated off of context, we can continue the refactor of lifting state out of view components.

This first pass removes the chat view's subscription to the message history store and passes the message array instead of a store as props.