### PR TITLE
feat: add impression information to session requests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -128,7 +128,6 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENAI_BASE_URL: https://api.openai.com/v1
       # Frontend playwright tests
-      VITE_RAILS_API_BASE_URL: http://localhost:3000
       VITE_OPENAI_BASE_URL: http://localhost:5555/openai/v1
       VITE_E2E_WALLET_KEY: ${{ secrets.VITE_E2E_WALLET_KEY }}
       VITE_E2E_WALLET_MNEMONIC: ${{ secrets.VITE_E2E_WALLET_MNEMONIC }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -128,6 +128,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENAI_BASE_URL: https://api.openai.com/v1
       # Frontend playwright tests
+      VITE_RAILS_API_BASE_URL: http://localhost:3000
       VITE_OPENAI_BASE_URL: http://localhost:5555/openai/v1
       VITE_E2E_WALLET_KEY: ${{ secrets.VITE_E2E_WALLET_KEY }}
       VITE_E2E_WALLET_MNEMONIC: ${{ secrets.VITE_E2E_WALLET_MNEMONIC }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,6 +18,7 @@ jobs:
       VITE_E2E_WALLET_ADDRESS: ${{ secrets.VITE_E2E_WALLET_ADDRESS }}
       VITE_FEAT_UPDATED_DESIGN: true
       VITE_FEAT_QWEN: false
+      VITE_RAILS_API_BASE_URL: http://localhost:3000
     steps:
       - uses: actions/checkout@v4
 

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -5,10 +5,12 @@ import { join } from 'path';
 
 const { describe } = test;
 
-test.beforeEach(async ({ page }) => {
-  // This guarantees /session won't cause ERR_CONNECTION_REFUSED
-  await page.route('**/session**', (route) => {
-    route.fulfill({ status: 204, body: '' });
+test.beforeEach(async ({ context }) => {
+  await context.route('**/session**', (route) => {
+    route.fulfill({
+      status: 204,
+      body: '',
+    });
   });
 });
 

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -5,6 +5,13 @@ import { join } from 'path';
 
 const { describe } = test;
 
+test.beforeEach(async ({ page }) => {
+  // This guarantees /session won't cause ERR_CONNECTION_REFUSED
+  await page.route('**/session**', (route) => {
+    route.fulfill({ status: 204, body: '' });
+  });
+});
+
 describe('chat', () => {
   test('renders intro messages by model', async ({ page }) => {
     const initialIntroMessage = 'What can I help you with?';

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -5,12 +5,19 @@ import { join } from 'path';
 
 const { describe } = test;
 
-test.beforeEach(async ({ context }) => {
+test.beforeEach(async ({ page, context }) => {
   await context.route('**/session**', (route) => {
-    route.fulfill({
-      status: 204,
-      body: '',
-    });
+    route.fulfill({ status: 204, body: '' });
+  });
+
+  // 🚨 Log browser console output to see errors
+  page.on('console', (msg) => {
+    console.log(`[browser][${msg.type()}] ${msg.text()}`);
+  });
+
+  // 🧪 Also catch page errors
+  page.on('pageerror', (err) => {
+    console.log('[browser][pageerror]', err);
   });
 });
 

--- a/src/useSession.test.tsx
+++ b/src/useSession.test.tsx
@@ -112,7 +112,7 @@ describe('useSession', () => {
     const expectedUrl = buildSessionUrlWithQueryParams(
       MOCK_RAILS_URL,
       window.location.href,
-      'null',
+      'nil',
     );
 
     setupSessionHook();

--- a/src/useSession.test.tsx
+++ b/src/useSession.test.tsx
@@ -62,26 +62,16 @@ describe('useSession', () => {
     setupSessionHook();
 
     expect(fetchSpy).toHaveBeenCalledWith(
-<<<<<<< HEAD
       sessionUrl,
       expect.objectContaining({ method: 'GET' }),
-=======
-      expect.stringContaining(sessionUrl),
-      expect.any(Object),
->>>>>>> 360cd51 (feat: add impression information to session requests)
     );
 
     advanceMinutesAndMs(5);
     window.dispatchEvent(new Event('click'));
 
     expect(fetchSpy).toHaveBeenCalledWith(
-<<<<<<< HEAD
       sessionUrl,
       expect.objectContaining({ method: 'GET' }),
-=======
-      expect.stringContaining(sessionUrl),
-      expect.objectContaining({ method: 'POST' }),
->>>>>>> 360cd51 (feat: add impression information to session requests)
     );
   });
 
@@ -112,7 +102,7 @@ describe('useSession', () => {
     const expectedUrl = buildSessionUrlWithQueryParams(
       MOCK_RAILS_URL,
       window.location.href,
-      'nil',
+      'null',
     );
 
     setupSessionHook();
@@ -191,25 +181,13 @@ describe('useSession', () => {
 
       advanceMinutesAndMs(4);
       window.dispatchEvent(new Event(eventType));
-<<<<<<< HEAD
-=======
-      expect(fetchSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining(sessionUrl),
-        expect.objectContaining({ method: 'POST' }),
-      );
->>>>>>> 360cd51 (feat: add impression information to session requests)
 
       advanceMinutesAndMs(1, 1);
       window.dispatchEvent(new Event(eventType));
 
       expect(fetchSpy).toHaveBeenCalledWith(
-<<<<<<< HEAD
         sessionUrl,
         expect.objectContaining({ method: 'GET' }),
-=======
-        expect.stringContaining(sessionUrl),
-        expect.objectContaining({ method: 'POST' }),
->>>>>>> 360cd51 (feat: add impression information to session requests)
       );
 
       expect(fetchSpy).toHaveBeenCalledTimes(2);
@@ -232,25 +210,12 @@ describe('useSession', () => {
     window.dispatchEvent(new Event('wheel'));
     window.dispatchEvent(new Event('touchstart'));
 
-<<<<<<< HEAD
-=======
-    expect(fetchSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining(sessionUrl),
-      expect.objectContaining({ method: 'POST' }),
-    );
-
->>>>>>> 360cd51 (feat: add impression information to session requests)
     advanceMinutesAndMs(4, 1);
     window.dispatchEvent(new Event('keydown'));
 
     expect(fetchSpy).toHaveBeenCalledWith(
-<<<<<<< HEAD
       sessionUrl,
       expect.objectContaining({ method: 'GET' }),
-=======
-      expect.stringContaining(sessionUrl),
-      expect.objectContaining({ method: 'POST' }),
->>>>>>> 360cd51 (feat: add impression information to session requests)
     );
 
     expect(fetchSpy).toHaveBeenCalledTimes(2);
@@ -271,25 +236,12 @@ describe('useSession', () => {
     });
     document.dispatchEvent(new Event('visibilitychange'));
 
-<<<<<<< HEAD
-=======
-    expect(fetchSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining(sessionUrl),
-      expect.objectContaining({ method: 'POST' }),
-    );
-
->>>>>>> 360cd51 (feat: add impression information to session requests)
     advanceMinutesAndMs(1, 1);
     document.dispatchEvent(new Event('visibilitychange'));
 
     expect(fetchSpy).toHaveBeenCalledWith(
-<<<<<<< HEAD
       sessionUrl,
       expect.objectContaining({ method: 'GET' }),
-=======
-      expect.stringContaining(sessionUrl),
-      expect.objectContaining({ method: 'POST' }),
->>>>>>> 360cd51 (feat: add impression information to session requests)
     );
 
     expect(fetchSpy).toHaveBeenCalledTimes(2);
@@ -356,13 +308,13 @@ describe('buildSessionUrlWithQueryParams', () => {
     expect(result).toContain(encodeURIComponent(REFERRER_URL));
   });
 
-  it('uses "nil" if referrer_url is missing', () => {
+  it('uses "null" if referrer_url is missing', () => {
     const result = buildSessionUrlWithQueryParams(
       MOCK_RAILS_URL,
       LANDING_URL,
-      'nil',
+      'null',
     );
-    expect(result).toContain('referrer_url=nil');
+    expect(result).toContain('referrer_url=null');
   });
 });
 

--- a/src/useSession.test.tsx
+++ b/src/useSession.test.tsx
@@ -356,13 +356,13 @@ describe('buildSessionUrlWithQueryParams', () => {
     expect(result).toContain(encodeURIComponent(REFERRER_URL));
   });
 
-  it('uses "null" if referrer_url is missing', () => {
+  it('uses "nil" if referrer_url is missing', () => {
     const result = buildSessionUrlWithQueryParams(
       MOCK_RAILS_URL,
       LANDING_URL,
-      'null',
+      'nil',
     );
-    expect(result).toContain('referrer_url=null');
+    expect(result).toContain('referrer_url=nil');
   });
 });
 

--- a/src/useSession.tsx
+++ b/src/useSession.tsx
@@ -11,7 +11,7 @@ export function useSession() {
     lastPingTimeRef.current = Date.now();
 
     const landingUrl = window.location.href;
-    const referrerUrl = document.referrer || 'null';
+    const referrerUrl = document.referrer || 'nil';
     const urlWithParams = buildSessionUrlWithQueryParams(
       sessionUrl,
       landingUrl,

--- a/src/useSession.tsx
+++ b/src/useSession.tsx
@@ -9,7 +9,16 @@ export function useSession() {
 
   const getSession = (keepAlive = false) => {
     lastPingTimeRef.current = Date.now();
-    fetch(sessionUrl, {
+
+    const landingUrl = window.location.href;
+    const referrerUrl = document.referrer || 'null';
+    const urlWithParams = buildSessionUrlWithQueryParams(
+      sessionUrl,
+      landingUrl,
+      referrerUrl,
+    );
+
+    fetch(urlWithParams, {
       method: 'GET',
       credentials: 'include',
       headers: {
@@ -68,3 +77,30 @@ export function useSession() {
     };
   }, []);
 }
+
+export const buildSessionUrlWithQueryParams = (
+  baseUrl: string,
+  landingPageUrl: string,
+  referrerUrl: string,
+): string => {
+  const sessionUrl = new URL(baseUrl);
+  sessionUrl.searchParams.set('landing_page_url', landingPageUrl);
+  sessionUrl.searchParams.set('referrer_url', referrerUrl);
+  return sessionUrl.toString();
+};
+
+export const resetLandingPageUrlQueryParams = (urlString: string): string => {
+  const url = new URL(urlString);
+  const params = url.searchParams;
+  const keysToRemove = [];
+
+  for (const key of params.keys()) {
+    if (key.toLowerCase().startsWith('utm_')) {
+      keysToRemove.push(key);
+    }
+  }
+
+  keysToRemove.forEach((key) => params.delete(key));
+
+  return `${url.origin}${url.pathname}${params.toString() ? '?' + params.toString() : ''}`;
+};

--- a/src/useSession.tsx
+++ b/src/useSession.tsx
@@ -1,14 +1,13 @@
 import { useEffect, useRef } from 'react';
 
-const RAILS_API_BASE_URL =
-  import.meta.env.VITE_RAILS_API_BASE_URL || 'http://localhost:3000';
+const RAILS_API_BASE_URL = import.meta.env.VITE_RAILS_API_BASE_URL ?? '';
 export const sessionUrl = `${RAILS_API_BASE_URL}/session`;
 const FIVE_MINUTES = 5 * 60 * 1000;
 
 export function useSession() {
   const lastPingTimeRef = useRef<number>(Date.now());
 
-  const getSession = (keepAlive = false) => {
+  const getSession = (keepAlive = true) => {
     lastPingTimeRef.current = Date.now();
 
     const landingUrl = window.location.href;
@@ -29,6 +28,9 @@ export function useSession() {
     }).catch(() => {
       // silently fail
     });
+
+    const cleanedUrl = resetLandingPageUrlQueryParams(landingUrl);
+    window.history.replaceState({}, '', cleanedUrl);
   };
 
   useEffect(() => {
@@ -37,7 +39,7 @@ export function useSession() {
     const handleUserActivity = () => {
       const now = Date.now();
       if (now - lastPingTimeRef.current >= FIVE_MINUTES) {
-        getSession(true);
+        getSession();
       }
     };
 
@@ -45,12 +47,12 @@ export function useSession() {
       if (document.visibilityState === 'visible') {
         handleUserActivity();
       } else if (document.visibilityState === 'hidden') {
-        getSession(true); // Send keepalive ping before tab closes
+        getSession(); // Send keepalive ping before tab closes
       }
     };
 
     const handlePagehide = () => {
-      getSession(true); // Also send keepalive on pagehide
+      getSession(); // Also send keepalive on pagehide
     };
 
     const userActivityEvents = [

--- a/src/useSession.tsx
+++ b/src/useSession.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 
-const RAILS_API_BASE_URL = import.meta.env.VITE_RAILS_API_BASE_URL ?? '';
+const RAILS_API_BASE_URL =
+  import.meta.env.VITE_RAILS_API_BASE_URL || 'http://localhost:3000';
 export const sessionUrl = `${RAILS_API_BASE_URL}/session`;
 const FIVE_MINUTES = 5 * 60 * 1000;
 

--- a/src/useSession.tsx
+++ b/src/useSession.tsx
@@ -96,15 +96,12 @@ export const buildSessionUrlWithQueryParams = (
 export const resetLandingPageUrlQueryParams = (urlString: string): string => {
   const url = new URL(urlString);
   const params = url.searchParams;
-  const keysToRemove = [];
 
-  for (const key of params.keys()) {
+  for (const key of Array.from(params.keys())) {
     if (key.toLowerCase().startsWith('utm_')) {
-      keysToRemove.push(key);
+      params.delete(key);
     }
   }
-
-  keysToRemove.forEach((key) => params.delete(key));
 
   return `${url.origin}${url.pathname}${params.toString() ? '?' + params.toString() : ''}`;
 };


### PR DESCRIPTION
## Summary
- track impressions better from campaign driven events to the rails backend
- track `landing_page_url` and `referrer_url` on app load
- include them as query params to the backend session request
- after session request set, remove utm params from url
