### PR TITLE
fix: Do not send empty tool array for completions

### DIFF
--- a/src/core/context/utils.ts
+++ b/src/core/context/utils.ts
@@ -166,7 +166,9 @@ export async function doChat(
       {
         model: id,
         messages: messagesWithoutReasoningContent,
-        tools: tools,
+        // Only include tools if they exist and are non-empty.
+        // An empty array of tools can cause models to misbehave and return invalid output or loop
+        ...(tools && tools.length ? { tools } : {}),
         stream: true,
         stream_options: { include_usage: modelConfig.includeUsageInStream },
       },


### PR DESCRIPTION
An empty array causes issues with o3-mini, causing looping responses and invalid outputs.  If no tools exist, it's better to leave the value as undefined.

## Summary

## Demo 

## Open Questions

## Follow-on tasks
