### PR TITLE
feat: drop POST requests in favor of GET keepalive

### DIFF
--- a/e2e/Chat.ts
+++ b/e2e/Chat.ts
@@ -8,7 +8,7 @@ export class Chat {
     this.page = page;
 
     // Mock the /session endpoint for both GET and POST
-    this.page.route('**/session', async (route, request) => {
+    this.page.route('**/session', async (route, _request) => {
       route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/src/core/components/Conversation/Content.test.tsx
+++ b/src/core/components/Conversation/Content.test.tsx
@@ -22,7 +22,6 @@ describe('Content Component', () => {
       mockSanitizedContent,
     );
 
-
     // Mock requestAnimationFrame
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
       callback(0);

--- a/src/useSession.tsx
+++ b/src/useSession.tsx
@@ -7,23 +7,10 @@ const FIVE_MINUTES = 5 * 60 * 1000;
 export function useSession() {
   const lastPingTimeRef = useRef<number>(Date.now());
 
-  const getSession = () => {
+  const getSession = (keepAlive = false) => {
     lastPingTimeRef.current = Date.now();
     fetch(sessionUrl, {
       method: 'GET',
-      credentials: 'include',
-      headers: {
-        Accept: 'application/json',
-      },
-    }).catch(() => {
-      // silently fail
-    });
-  };
-
-  const postHeartbeat = (keepAlive = false) => {
-    lastPingTimeRef.current = Date.now();
-    fetch(sessionUrl, {
-      method: 'POST',
       credentials: 'include',
       headers: {
         Accept: 'application/json',
@@ -40,7 +27,7 @@ export function useSession() {
     const handleUserActivity = () => {
       const now = Date.now();
       if (now - lastPingTimeRef.current >= FIVE_MINUTES) {
-        postHeartbeat();
+        getSession(true);
       }
     };
 
@@ -48,12 +35,12 @@ export function useSession() {
       if (document.visibilityState === 'visible') {
         handleUserActivity();
       } else if (document.visibilityState === 'hidden') {
-        postHeartbeat(true); // Send keepalive ping before tab closes
+        getSession(true); // Send keepalive ping before tab closes
       }
     };
 
     const handlePagehide = () => {
-      postHeartbeat(true); // Also send keepalive on pagehide
+      getSession(true); // Also send keepalive on pagehide
     };
 
     const userActivityEvents = [


### PR DESCRIPTION
## Summary
- remove the POST /session for heartbeat in favor of keepalive since it works on all requests and accomplishes the same thing
## Demo 

## Open Questions

## Follow-on tasks
