### PR TITLE
fix: Disable otelhttp subspans

### DIFF
--- a/api/internal/types/client.go
+++ b/api/internal/types/client.go
@@ -35,7 +35,7 @@ func NewOpenAIClient(baseURL, apiKey string) *OpenAIPassthroughClient {
 			Transport: otelhttp.NewTransport(
 				http.DefaultTransport,
 				otelhttp.WithClientTrace(func(ctx context.Context) *httptrace.ClientTrace {
-					return otelhttptrace.NewClientTrace(ctx)
+					return otelhttptrace.NewClientTrace(ctx, otelhttptrace.WithoutSubSpans())
 				}),
 				otelhttp.WithMetricAttributesFn(func(r *http.Request) []attribute.KeyValue {
 					attrs := []attribute.KeyValue{}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,10 @@ services:
       KAVACHAT_API_HOST: '0.0.0.0'
       KAVACHAT_API_BACKEND_0_NAME: 'OpenAI'
 
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://awscollector:4317
+      OTEL_SERVICE_NAME: kavachat-api
+      OTEL_RESOURCE_ATTRIBUTES: service.name=kavachat-api,aws.service=kavachat-api
+
       # Localstack
       AWS_ENDPOINT_URL: http://localstack:4566
       AWS_REGION: us-east-1
@@ -61,44 +65,44 @@ services:
       - '5778'
       - '9411'
 
-  kavanode:
-    image: 'kava/kava:${KAVA_TAG:-v0.27.0-goleveldb}'
-    ports:
-      # open default kava rpc port
-      - '26657:26657'
-      # open rest port
-      - '1317:1317'
-      # open grpc port
-      - '9090:9090'
-      # open grpc-web port
-      - '9091:9091'
-      # open EVM JSON-RPC port
-      - '8545:8545'
-      # open Eth websocket port
-      - '8546:8546'
-    volumes:
-      - './tests/kvtool/full_configs/generated/kava/initstate/.kava:/root/.kava'
-    # start the blockchain, and set rpc to listen to connections from outside the container
-    command:
-      - 'sh'
-      - '-c'
-      - '/root/.kava/config/init-data-directory.sh && kava start --rpc.laddr=tcp://0.0.0.0:26657'
-    # kava image does not have healthcheck built in, so we add one here
-    healthcheck:
-      # Check if kava EVM JSON-RPC is up
-      test:
-        [
-          'CMD',
-          'curl',
-          '-f',
-          '-X',
-          'POST',
-          '-H',
-          'Content-Type: application/json',
-          'http://localhost:8545',
-        ]
-      interval: 30s
-      timeout: 30s
-      start_period: 1m
-      start_interval: 5s
-      retries: 3
+  # kavanode:
+  #   image: 'kava/kava:${KAVA_TAG:-v0.27.0-goleveldb}'
+  #   ports:
+  #     # open default kava rpc port
+  #     - '26657:26657'
+  #     # open rest port
+  #     - '1317:1317'
+  #     # open grpc port
+  #     - '9090:9090'
+  #     # open grpc-web port
+  #     - '9091:9091'
+  #     # open EVM JSON-RPC port
+  #     - '8545:8545'
+  #     # open Eth websocket port
+  #     - '8546:8546'
+  #   volumes:
+  #     - './tests/kvtool/full_configs/generated/kava/initstate/.kava:/root/.kava'
+  #   # start the blockchain, and set rpc to listen to connections from outside the container
+  #   command:
+  #     - 'sh'
+  #     - '-c'
+  #     - '/root/.kava/config/init-data-directory.sh && kava start --rpc.laddr=tcp://0.0.0.0:26657'
+  #   # kava image does not have healthcheck built in, so we add one here
+  #   healthcheck:
+  #     # Check if kava EVM JSON-RPC is up
+  #     test:
+  #       [
+  #         'CMD',
+  #         'curl',
+  #         '-f',
+  #         '-X',
+  #         'POST',
+  #         '-H',
+  #         'Content-Type: application/json',
+  #         'http://localhost:8545',
+  #       ]
+  #     interval: 30s
+  #     timeout: 30s
+  #     start_period: 1m
+  #     start_interval: 5s
+  #     retries: 3


### PR DESCRIPTION
"client" span types instead of "internal" produces inferred nodes in x-ray. Use events instead of subspans, so they don't produce additional nodes
