### PR TITLE
fix: Use explicit Content-Length header

### DIFF
--- a/api/cmd/api/server_test.go
+++ b/api/cmd/api/server_test.go
@@ -55,6 +55,10 @@ func newHttpMockServer(authHeader string) *httptest.Server {
 					headersMatch = false
 				}
 			}
+			// Panic if Content-Length header does not exist
+			if r.Header.Get("Content-Length") == "" {
+				panic("Content-Length header is missing")
+			}
 			if !headersMatch {
 				continue
 			}

--- a/api/internal/handlers/openai.go
+++ b/api/internal/handlers/openai.go
@@ -192,12 +192,12 @@ func (h openaiProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	)
 	defer responseWriter.End()
 
-	// Forward request with a new ReadCloser
+	// Forward request
 	apiResponse, err := client.DoRequest(
 		ctx,
 		r.Method,
 		h.endpoint,
-		io.NopCloser(bytes.NewReader(bodyBytes)),
+		bytes.NewReader(bodyBytes),
 	)
 	if err != nil {
 		// Check if error is specifically due to client disconnection

--- a/api/internal/types/client.go
+++ b/api/internal/types/client.go
@@ -1,9 +1,9 @@
 package types
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptrace"
 	"net/http/httputil"
@@ -66,7 +66,7 @@ func (c *OpenAIPassthroughClient) DoRequest(
 	ctx context.Context,
 	method,
 	path string,
-	body io.ReadCloser,
+	body *bytes.Reader, // *bytes.Reader which sets the Content-Length header
 ) (*http.Response, error) {
 	// To properly build URL:
 	// BaseURL should NOT have a trailing slash
@@ -98,7 +98,7 @@ func (c *OpenAIPassthroughClient) DoRequest(
 
 	// Dump the raw outgoing HTTP request for debugging
 	if dump, err := httputil.DumpRequestOut(req, true); err == nil {
-		fmt.Printf("RAW BACKEND REQUEST:\n%s\n", string(dump))
+		fmt.Printf("RAW BACKEND REQUEST:\n%q\n", string(dump))
 	} else {
 		fmt.Printf("Failed to dump request: %v\n", err)
 	}


### PR DESCRIPTION
Using `Transfer-Encoding: chunked` replicates "Invalid HTTP request received." response error from vLLM.

Using explicit Content-Length avoids chunked encoding.

http docs: https://pkg.go.dev/net/http#NewRequestWithContext
> If body is of type [*bytes.Buffer](https://pkg.go.dev/bytes#Buffer), [*bytes.Reader](https://pkg.go.dev/bytes#Reader), or [*strings.Reader](https://pkg.go.dev/strings#Reader), the returned request's ContentLength is set to its exact value (instead of -1), GetBody is populated (so 307 and 308 redirects can replay the body), and Body is set to [NoBody](https://pkg.go.dev/net/http#NoBody) if the ContentLength is 0.