### PR TITLE
feat: switchover backend from custom to litellm

### DIFF
--- a/src/core/config/models/models.ts
+++ b/src/core/config/models/models.ts
@@ -106,8 +106,8 @@ export const MODEL_REGISTRY: Record<SupportedModels, ModelConfig> = {
   //   introText: defaultIntroText,
   //   inputPlaceholderText: defaultInputPlaceholderText,
   // },
-  'Qwen/Qwen3-30B-A3B-FP8': {
-    id: 'Qwen/Qwen3-30B-A3B-FP8',
+  'qwen3-30b-a3b': {
+    id: 'qwen3-30b-a3b', // NOTE: this model has a different id if not served via litellm
     name: 'Experimental: Qwen3-30B-A3B',
     reasoningModel: true,
     icon: KavaIcon,

--- a/src/core/types/models.ts
+++ b/src/core/types/models.ts
@@ -11,7 +11,7 @@ export const supportedModels = [
   // 'deepseek-r1',
   // 'gpt-4o',
   'o3-mini',
-  'Qwen/Qwen3-30B-A3B-FP8',
+  'qwen3-30b-a3b',
 ] as const;
 
 export type SupportedModels = (typeof supportedModels)[number];

--- a/src/core/utils/token/token.ts
+++ b/src/core/utils/token/token.ts
@@ -2,6 +2,9 @@ import { v4 as uuidv4 } from 'uuid';
 
 export const IDKEY = 'id';
 
+export const USE_LITELLM_TOKEN =
+  import.meta.env.VITE_FEAT_USE_LITELLM_TOKEN === 'true';
+
 /**
  * Retrieves an ID from the specified storage (localStorage or sessionStorage).
  * If no ID exists, a new UUID is generated, stored, and returned.
@@ -35,6 +38,13 @@ export function getIDFromStorage(storage: Storage) {
  * @returns {string} The token in the format "kavachat:{clientID}:{sessionID}".
  */
 export function getToken() {
+  if (USE_LITELLM_TOKEN) {
+    // using LiteLLM service account token here is no different from a security standpoint
+    // form having an unauthenticated endpoint. the benefit here is we could rotate the key
+    // on deployment. When the need arises, we can implement custom auth middleware and fetch
+    // the token here.
+    return import.meta.env.VITE_LITELLM_API_KEY;
+  }
   const clientToken = getIDFromStorage(window.localStorage);
   const sessionToken = getIDFromStorage(window.sessionStorage);
   return `kavachat:${clientToken}:${sessionToken}`;


### PR DESCRIPTION
## Summary

Makes the necessary changes to use LiteLLM as the backend.

This uses a raw litellm virtual token in all chat requests. This is no less safe than an unauthenticated endpoint. We'll be able to monitor usage and could implement key rotation on deployment if desired. For true auth, we can implement a custom auth middleware in the backend.


**DON'T MERGE ME UNTIL PROD ENV VARS HAVE BEEN UPDATED**. I've updated them so that the generated deployment preview uses the new backend.