### PR TITLE
fix: use gpt-4o-mini for image analysis

### DIFF
--- a/src/core/config/models/models.ts
+++ b/src/core/config/models/models.ts
@@ -1,13 +1,17 @@
+import KavaIcon from '../../assets/KavaIcon';
 import { ModelConfig, SupportedModels } from '../../types/models';
 import {
+  defaultInputPlaceholderText,
   defaultIntroText,
   defaultSystemPrompt,
-  defaultInputPlaceholderText,
 } from './defaultPrompts';
-import KavaIcon from '../../assets/KavaIcon';
 import { calculateFinalChunkTokenUsage } from './helpers';
 // import { calculateGptContextMetrics } from '../../utils/conversation/helpers';
 
+/** The model used to analyze images */
+export const IMAGE_ANALYSIS_MODEL = 'gpt-4o-mini';
+/** The model used to generate titles for user conversations */
+export const CONVERSATION_TITLE_MODEL = 'gpt-4o-mini';
 export const MODEL_REGISTRY: Record<SupportedModels, ModelConfig> = {
   'qwq-32b-bnb-4bit': {
     id: 'qwq-32b-bnb-4bit',

--- a/src/core/context/utils.ts
+++ b/src/core/context/utils.ts
@@ -1,23 +1,27 @@
-import { v4 as uuidv4 } from 'uuid';
 import {
   ConversationHistory,
+  formatConversationTitle,
   getAllConversations,
   saveConversation,
   TextStreamStore,
 } from 'lib-kava-ai';
-import { MessageHistoryStore } from '../stores/messageHistoryStore';
 import OpenAI from 'openai';
-import { ModelConfig } from '../types/models';
-import { isContentChunk, isReasoningChunk } from '../utils/streamUtils';
-import { formatConversationTitle } from 'lib-kava-ai';
 import {
   ChatCompletionChunk,
   ChatCompletionContentPart,
   ChatCompletionMessageParam,
 } from 'openai/resources/index';
-import { getImage } from '../utils/idb/idb';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  CONVERSATION_TITLE_MODEL,
+  IMAGE_ANALYSIS_MODEL,
+  isReasoningModel,
+} from '../config/models';
 import { visionModelPrompt } from '../config/models/defaultPrompts';
-import { isReasoningModel } from '../config/models';
+import { MessageHistoryStore } from '../stores/messageHistoryStore';
+import { ModelConfig } from '../types/models';
+import { getImage } from '../utils/idb/idb';
+import { isContentChunk, isReasoningChunk } from '../utils/streamUtils';
 
 export const newConversation = () => {
   return {
@@ -36,7 +40,7 @@ const analyzeImage = async (
   msg: ChatCompletionMessageParam,
 ) => {
   const data = await client.chat.completions.create({
-    model: 'qwen2.5-vl-7b-instruct',
+    model: IMAGE_ANALYSIS_MODEL,
     messages: [msg],
   });
 
@@ -371,7 +375,7 @@ export async function syncWithLocalStorage(
                       `,
           },
         ],
-        model: 'gpt-4o-mini',
+        model: CONVERSATION_TITLE_MODEL,
       });
 
       // Apply truncation only when we get the AI-generated title


### PR DESCRIPTION
updates the model that does image analysis from the no-longer-existing qwen2.5 one to openai's gpt-4o-mini.

## Summary

confirmed that it can properly analyze images by using gpt-4o-mini.

also confirmed that chatgpt does not know who kermit the frog is:
<img width="855" alt="Screenshot 2025-06-05 at 12 05 25" src="https://github.com/user-attachments/assets/b073b0ec-9b85-4b50-9ea2-b82b09b89a77" />
